### PR TITLE
docs: align HyperGrok with Grok plugin research

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "hypergrok",
+  "description": "Create a risk-bounded Hyperliquid trading desk on Grok Bot.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Galleon Labs"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -31,11 +31,27 @@ hypergrok market BTC
 hypergrok size --equity 10000 --entry 100 --stop 95 --risk-pct 0.5 --max-notional 1000
 ```
 
-Grok Bot plugin installation from a private GitHub repository is still being
-verified against the live product. The repository follows the Agent Plugins
-manifest plus the observed `.grok-plugin` layout. Do not mistake a plausible
-click path for a tested one. For SKILL-compatible agents, clone the repository
-or use `npx skills add galleonlabs/hypergrok-trading-desk` once it is public.
+Grok Bot does not document a native “install this arbitrary GitHub URL” command.
+The supported private distribution route is inferred from the Cursor plugin
+infrastructure used by Grok Bot:
+
+1. A Cursor team administrator opens **Dashboard -> Plugins**.
+2. Under **Team Marketplaces**, choose **Add Marketplace -> Import from Repo**.
+3. Import this GitHub repository and grant the Cursor GitHub App read access.
+4. In Grok Bot, enable HyperGrok under **Settings -> Plugins -> Yours** for the
+   intended Bot.
+
+This repository now carries the portable Agent Plugins manifest, the observed
+`.grok-plugin` manifest and the official Cursor `.cursor-plugin` manifest. The
+managed installation still needs an end-to-end receipt from the live private
+product before launch. Cloning the repository into the shared cloud computer is
+ordinary computer use, not a durable installation contract. For other
+SKILL-compatible agents, clone the repository or use
+`npx skills add galleonlabs/hypergrok-trading-desk` once it is public.
+
+Grok Bots belonging to one user share a cloud computer, files and sign-ins. Bot
+identity is not a credential boundary. Use a narrowly authorised API wallet and
+assume every Bot on that user account can reach any credential placed there.
 
 ## Order flow
 

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -5,12 +5,13 @@ interfaces and product gaps, not copied.
 
 | Source | Use | Licence / status |
 | --- | --- | --- |
-| Hyperliquid docs and Python SDK | API fields, signing client, builder rules | Docs; SDK MIT |
-| DefiLlama API docs and skills | Endpoint coverage and research gaps | Public docs; skills repo had no detected licence on 16 Aug 2026, so no code or prose reused |
-| CoinGecko docs and skills | Auth tiers and endpoint coverage | Public docs; no code or prose reused |
-| Senpi skills | Comparative capability survey only | MIT; no code, prose, fixtures, names or strategies reused |
-| Agent Plugins schema | Manifest interoperability | Public specification |
-| Community Grok plugin examples | Packaging evidence only | MIT |
+| Hyperliquid docs and Python SDK `2fdb18f` | API fields, signing client, builder rules | Docs; SDK MIT |
+| DefiLlama API docs and skills `f286bda` | Endpoint coverage and research gaps | Public docs; skills repo had no detected licence on 16 Aug 2026, so no code or prose reused |
+| CoinGecko docs and skills `fcc056f` | Auth tiers and endpoint coverage | Official skills MIT; no code or prose reused |
+| Senpi skills `c3b6df3` | Comparative capability survey only | Root MIT and skill-level Apache-2.0 declarations conflict; no code, prose, fixtures, names or strategies reused |
+| Cursor and Grok Bot plugin documentation | Private installation and manifest conventions | Official documentation; Cursor route is a high-confidence inference because Grok Bot has no published GitHub-install contract |
+| Agent Plugins schema | Portable manifest interoperability | Public specification |
+| Community Grok plugin examples | Packaging evidence only | MIT; not treated as an official contract |
 
 Canonical receipts:
 
@@ -19,4 +20,8 @@ Canonical receipts:
 + https://github.com/hyperliquid-dex/hyperliquid-python-sdk
 + https://defillama.com/docs/api
 + https://docs.coingecko.com/ai-integration
++ https://docs.x.ai/grok-bot/skills-routines-and-automations
++ https://docs.x.ai/grok-bot/settings-and-notifications
++ https://cursor.com/docs/reference/plugins
++ https://cursor.com/docs/plugins#team-marketplaces
 + https://agent-plugins.org/schemas/1.0.0/plugin.schema.json

--- a/docs/SHAPE.md
+++ b/docs/SHAPE.md
@@ -23,3 +23,19 @@ approval, hidden fees, return claims or unattended live trading.
 **Success signal:** a fresh install produces a cited brief and testnet plan;
 every failed execution gate proves zero sends; the one allowed send includes the
 disclosed builder object and a unique cloid.
+
+## Earned expansion
+
+The comparative survey found recurring gaps worth adding only after the private
+install and testnet execution receipts exist:
+
++ source ledger and asset identity resolution
++ protocol governance, oracle, bridge and upgrade underwriting
++ leakage-resistant strategy lab with holdout and walk-forward gates
++ cross-venue portfolio risk and liquidity-aware stress tests
++ durable execution receipts, partial-fill reconciliation and stale-feed alarms
++ watchkeeper and incident-captain runbooks for orphan orders and degraded APIs
+
+These are original capability targets, not a plan to import upstream skill prose
+or code. Hosted runtimes, strategy catalogues and unattended execution remain
+outside v0.1.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -7,8 +7,12 @@ ROOT = Path(__file__).parents[1]
 def test_manifests_agree() -> None:
     root = json.loads((ROOT / "plugin.json").read_text())
     grok = json.loads((ROOT / ".grok-plugin/plugin.json").read_text())
+    cursor = json.loads((ROOT / ".cursor-plugin/plugin.json").read_text())
     for field in ("name", "version", "repository", "license"):
         assert root[field] == grok[field]
+    for field in ("name", "version"):
+        assert root[field] == cursor[field]
+    assert cursor["author"]["name"] == "Galleon Labs"
 
 
 def test_every_skill_has_valid_frontmatter() -> None:


### PR DESCRIPTION
## Summary

- adds the official Cursor plugin manifest alongside portable and observed Grok manifests
- documents the supported private marketplace route and the lack of a native arbitrary-GitHub install contract
- records shared-cloud-computer credential boundaries
- pins clean-room research sources and licence caveats
- records the capability gaps that should earn later tranches

## Verification

- `ruff check .`
- `mypy src`
- `pytest -q` (19 passed)
- `git diff --check`

Repository remains private.