### PR TITLE
feat: HyperGrok v1.0 launch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,34 @@
+# Copy this file to .env and edit it:  cp .env.example .env
+#
+# The hypergrok command reads .env from this directory (or any parent) on every
+# run. Real environment variables always win, so you can still override any
+# single value inline, e.g. HYPERGROK_NETWORK=mainnet hypergrok doctor
+#
+# .env is gitignored. Never commit it.
+
 # Testnet is the safe default.
 HYPERGROK_NETWORK=testnet
-HYPERGROK_MAX_ORDER_NOTIONAL_USD=1000
+
+# --- Optional guardrails ----------------------------------------------------
+# HyperGrok imposes NO risk ceiling of its own. The real constraints come from
+# Hyperliquid -- per-asset max leverage, tiered margin, lot precision and a
+# 10 USD minimum order -- and `hypergrok limits <COIN>` reports them. Sizing
+# judgment belongs to your risk officer, not to a number in this file.
+#
+# Uncomment either line below only if you want the CLI itself to refuse a
+# fat-fingered figure. Left unset, there is no ceiling.
+#
+# HYPERGROK_MAX_ORDER_NOTIONAL_USD=1000
+# HYPERGROK_MAX_RISK_PCT=2
+
+# Not a ceiling: how far the live price may drift from your approved limit
+# before execution refuses. This is what makes "you approved this exact order"
+# mean something, so it always has a value. 30 bps = 0.3%, accepts up to 1000.
 HYPERGROK_MAX_SLIPPAGE_BPS=30
+# How long an order plan may stay valid, in minutes. Accepts up to 1440.
+HYPERGROK_MAX_PLAN_MINUTES=30
+# ----------------------------------------------------------------------------
+
 HYPERGROK_HTTP_TIMEOUT_SECONDS=15
 # Absolute private directory for one-attempt execution journals.
 # HYPERGROK_STATE_DIR=/home/you/.local/state/hypergrok/executions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to HyperGrok are recorded here.
 
 ## Unreleased
 
+### Setup and usability
+
++ Add `hypergrok quickstart`, a plain-English readiness check that prints the exact next step and never prints a key.
++ Load `.env` from the working directory or any parent. Previously `.env.example` documented settings that nothing read, so configuration was silently ignored. Real environment variables still win.
++ Make `plan-order` emit a copy-pasteable `next_command` including `--plan`.
++ Report account-specific setup in `doctor` rather than operational tasks that are not the user's to perform.
++ Rewrite the README around a ten-minute first run and explain the hash confirmation in plain language.
+
+### Risk limits
+
++ Add `hypergrok limits <COIN>`, reporting the constraints Hyperliquid itself enforces: per-asset max leverage, tiered margin, size decimals and the 10 USD minimum order value.
++ Remove HyperGrok's own risk-per-trade and notional ceilings. Both are now opt-in via `HYPERGROK_MAX_RISK_PCT` and `HYPERGROK_MAX_ORDER_NOTIONAL_USD`; unset means no ceiling. Sizing judgment belongs to the risk officer working from exchange limits.
++ Enforce Hyperliquid's 10 USD minimum order value at plan time.
++ Widen the slippage tolerance range and make the plan lifetime configurable, keeping the 30-minute default.
+
+### Execution
+
++ Stop attribution eligibility from blocking execution. An order that cannot carry attribution is now sent without it rather than refused; every user-safety gate is unchanged.
++ Apply attribution on mainnet only.
+
+### Verification
+
++ Add three live verification harnesses: `scripts/verify_cli.py`, `scripts/verify_repo.py` and `scripts/verify_skills.py`.
+
 + Make `BOOTSTRAP.md` the single Grok Bot entry point and define a supported two-group desk topology.
 + Add a finite SDK send timeout and read-only cloid reconciliation command.
 + Enforce the current configured slippage cap again at execution time.

--- a/README.md
+++ b/README.md
@@ -4,27 +4,38 @@
 [![MIT licence](https://img.shields.io/badge/licence-MIT-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml)
 
-**Create a risk-bounded Hyperliquid trading desk with Grok Build, Cursor or a manually configured Grok Bot.**
+**Turn your Grok bots into a Hyperliquid trading desk.**
 
-HyperGrok packages seven specialist agents, eleven original skills and a guarded Python execution gateway. It covers Hyperliquid market and account intelligence, DefiLlama and CoinGecko research, thesis construction, deterministic risk, portfolio control, execution and post-trade review.
+HyperGrok gives your AI agents seven specialist roles, eleven skills and one
+guarded order path. They research markets, build a thesis, size it against real
+exchange limits, and put a single reviewed order in front of you for approval.
 
-Both Hyperliquid **testnet and mainnet** are supported. Testnet is the safe default; mainnet requires an explicit acknowledgement and passes through the same plan, risk, API-wallet and duplicate-order gates.
+Nothing is sent that you have not read first. HyperGrok never sees your seed
+phrase, cannot withdraw or transfer funds, and refuses any order that differs by
+a single character from the one you approved.
+
+---
 
 ## The desk
 
-| Role | Responsibility |
+| Role | What it does |
 | --- | --- |
-| Desk lead | Routes evidence and approvals between specialists |
-| Market analyst | Hyperliquid structure, liquidity, open interest and funding |
-| Onchain analyst | Protocol, token, governance and dependency research |
-| Portfolio manager | Whole-book exposure, margin and protection state |
-| Risk officer | Independent sizing and deterministic rejection gates |
-| Execution trader | The sole guarded order path |
-| Trade reviewer | Plan-versus-effect and execution-quality review |
+| **Desk lead** | Routes evidence and approvals between the specialists |
+| **Market analyst** | Hyperliquid structure, liquidity, open interest, funding |
+| **Onchain analyst** | Protocol, token, governance and dependency research |
+| **Portfolio manager** | Whole-book exposure, margin and protection state |
+| **Risk officer** | Independent sizing, and the authority to refuse |
+| **Execution trader** | The only role that can reach the order path |
+| **Trade reviewer** | Plan versus effect, and execution quality |
 
-The Cursor plugin manifest discovers `agents/`, `skills/` and the persistent team rule. Start with [BOOTSTRAP.md](BOOTSTRAP.md). Grok Bot documents collaboration between named Bots but not a public API for silently creating them, so `crew-bootstrap` verifies the installed product and falls back to plugin agents or role-separated passes rather than inventing a one-click claim.
+Six of the seven cannot place an order at all. That separation is the point.
 
-## Install
+---
+
+## Quick start
+
+You need **Python 3.11+** and about ten minutes. You do **not** need funds, a
+wallet or a key to research and plan trades — only to place them.
 
 ```bash
 git clone https://github.com/galleonlabs/hypergrok-trading-desk.git
@@ -32,32 +43,73 @@ cd hypergrok-trading-desk
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install -e .
-hypergrok doctor
+cp .env.example .env
+hypergrok quickstart
 ```
 
-For development:
+`quickstart` checks your setup in plain English and tells you exactly what to do
+next. It never prints a key.
+
+```
+HyperGrok setup
+
+Network: testnet  (https://api.hyperliquid-testnet.xyz)
+Testnet is the safe default. No real money is at risk here.
+
+Configuration
+  [ok] Config file: /your/repo/.env
+  [ok] Hyperliquid reachable (2702 markets)
+
+You can research and plan orders. Placing them needs the account steps above.
+```
+
+Then try it:
 
 ```bash
-python -m pip install -e '.[dev]'
-ruff check .
-mypy src
-pytest -q --cov=hypergrok --cov-fail-under=75
-python -m build
+hypergrok market BTC                 # a live market
+hypergrok limits BTC --equity 10000  # what the exchange actually allows you
+hypergrok size --equity 10000 --entry 100 --stop 95 --risk-pct 0.5 --max-notional 1000
 ```
 
-## Set up the agent team
+### To place orders as well
+
+Three steps, in order:
+
+1. **Create an API wallet.** At [app.hyperliquid.xyz](https://app.hyperliquid.xyz)
+   open **Settings → API** and generate one. It can trade but cannot withdraw.
+   **Never** use your seed phrase or main wallet key.
+2. **Put it in `.env`.** Set `HYPERLIQUID_ACCOUNT_ADDRESS` to your trading
+   account and `HYPERLIQUID_PRIVATE_KEY` to the API wallet's key. `.env` is
+   already gitignored.
+3. **Run `hypergrok quickstart` again.** It confirms the API wallet is
+   authorised for that account.
+
+You stay on testnet until you deliberately opt into mainnet.
+
+---
+
+## Set up your agent team
 
 ### Grok Bot
 
 Open Grok Bot and paste this:
 
-> Set up HyperGrok from https://github.com/galleonlabs/hypergrok-trading-desk/blob/main/BOOTSTRAP.md. Follow that file from top to bottom, create the seven-role desk, and finish by showing me which roles and checks are working.
+> Set up HyperGrok from https://github.com/galleonlabs/hypergrok-trading-desk/blob/main/BOOTSTRAP.md.
+> Follow that file from top to bottom, create the seven-role desk, and finish by
+> showing me which roles and checks are working.
 
-[`BOOTSTRAP.md`](BOOTSTRAP.md) is the single entry point. If Grok cannot open the link, download that file and attach it to the conversation. It will ask for the other files it needs and guide the rest of the setup.
+[`BOOTSTRAP.md`](BOOTSTRAP.md) is the single entry point. If Grok cannot open the
+link, download the file and attach it to the conversation.
+
+Grok Bot has no public API for silently creating sibling Bots, so if it cannot
+create the seven itself it will hand you seven labelled setup blocks instead. We
+would rather tell you that than pretend it is one click. Without the `hypergrok`
+command available, a Grok Bot desk is research-and-review only.
 
 ### Grok Build or Cursor
 
-The Agent Plugin supplies the seven roles and skills. The Python install supplies the `hypergrok` command. Set up both from the repository:
+The Agent Plugin supplies the roles and skills; the Python install supplies the
+`hypergrok` command.
 
 ```bash
 uv sync --frozen
@@ -65,70 +117,170 @@ uv sync --frozen
 grok --plugin-dir .   # Grok Build
 ```
 
-Then run `/crew-bootstrap`. In Cursor, open the same repository, enable its local plugin, and run `crew-bootstrap`. The setup receipt must confirm whether the `hypergrok` command is available before any CLI-backed skill is used.
+Then run `/crew-bootstrap`. In Cursor, open the same repository, enable its local
+plugin and run `crew-bootstrap`. The setup receipt confirms whether the CLI is
+available before any CLI-backed skill is used.
 
-## Read both networks
+---
+
+## Placing an order
+
+Two commands, never one. That is deliberate.
+
+**1. Plan it.** Writes the order to a file. Touches no network, signs nothing.
+
+```bash
+hypergrok plan-order --account 0xYourAccount --coin BTC --side buy \
+  --size 0.001 --limit-px 95000 --out my-order.json
+```
+
+**2. Read the file, then run the command it gives you.** The output includes a
+`next_command` line you can copy verbatim.
+
+```bash
+hypergrok execute-order --plan my-order.json --confirm <sha256> --execute
+```
+
+### What the SHA-256 is for
+
+It is a fingerprint of your exact order file. Change one character — size, price,
+account, anything — and the fingerprint changes and the order is refused.
+
+You are not expected to read or understand the hash. You copy it. Its job is to
+guarantee that what gets sent is byte-for-byte what you reviewed, with no room
+for anything to alter it in between. Plans expire after 30 minutes for the same
+reason.
+
+### Every gate between you and a send
+
+`execute-order` checks all of these before a signing key is even imported:
+
+| Gate | Refuses when |
+| --- | --- |
+| Hash match | The plan file changed after you read it |
+| Expiry | The plan is stale |
+| Network | A testnet plan is run against mainnet, or vice versa |
+| Declared account | Your configured account differs from the plan |
+| Notional | The order exceeds a ceiling you opted into |
+| Price drift | The live price has moved beyond your tolerance |
+| Precision | Size or price breaks Hyperliquid tick and lot rules |
+| API wallet | The signing key is not an authorised wallet for that account |
+| Duplicate | The client order ID was already used |
+| Journal | This exact plan already reached the send boundary once |
+
+A timeout is an **unknown** result, not a failure. HyperGrok never retries;
+reconcile the order first with `hypergrok order-status`.
+
+---
+
+## Risk limits come from the exchange
+
+HyperGrok imposes **no risk-per-trade or notional ceiling of its own**. The real
+constraints are Hyperliquid's, they differ per asset, and they are tiered:
+
+```bash
+hypergrok limits BTC --equity 10000
+```
+
+reports max leverage, the margin tiers that apply as a position grows, size
+decimals and the 10 USD minimum order value.
+
+Headline leverage is the **top tier only** — BTC is 40x below 10k notional, 25x
+above it, 10x above 50k — so a size that looks financeable at the headline number
+may not be at the size you intend. Judging an appropriate risk budget from those
+limits is the risk officer's job; see [`skills/pretrade-risk`](skills/pretrade-risk/SKILL.md).
+
+### Optional guardrails
+
+Opt in if you want the CLI itself to catch a fat-fingered figure. Unset means no
+ceiling.
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `HYPERGROK_MAX_RISK_PCT` | unset | Refuse a `size` request above this percent of equity |
+| `HYPERGROK_MAX_ORDER_NOTIONAL_USD` | unset | Refuse a plan above this USD notional |
+
+These two are **not** ceilings and always have a value:
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `HYPERGROK_MAX_SLIPPAGE_BPS` | 30 | How far live price may drift from your approved limit |
+| `HYPERGROK_MAX_PLAN_MINUTES` | 30 | Longest a plan may stay valid, up to 1440 |
+
+What is **not** configurable is correctness: hash matching, account matching,
+API-wallet authorisation, duplicate protection, drift checking and tick rules.
+Those are not preferences.
+
+---
+
+## Safety
+
++ **Never provide a seed phrase or main-wallet key.** Use a scoped Hyperliquid
+  API wallet, which can trade but cannot withdraw.
++ **All Grok Bots belonging to one user share a cloud computer and sign-ins.**
+  Bot names are not credential boundaries.
++ **Mainnet requires `HYPERGROK_ENABLE_MAINNET=I_UNDERSTAND`.** Testnet is the
+  default and stays the default until you say otherwise.
++ **No deposits, withdrawals, transfers, bridging, reward claims or unattended
+  execution.** Those commands do not exist in this tool.
++ **No automatic retry** after the only send.
+
+Report a vulnerability via [SECURITY.md](SECURITY.md).
+
+---
+
+## Both networks
 
 ```bash
 # Testnet, the default
 hypergrok doctor
 hypergrok market BTC
 
-# Mainnet read-only and execution configuration
-HYPERGROK_NETWORK=mainnet \
-HYPERGROK_ENABLE_MAINNET=I_UNDERSTAND \
-hypergrok doctor
+# Mainnet, explicitly
+HYPERGROK_NETWORK=mainnet HYPERGROK_ENABLE_MAINNET=I_UNDERSTAND hypergrok doctor
 
-HYPERGROK_NETWORK=mainnet \
-HYPERGROK_ENABLE_MAINNET=I_UNDERSTAND \
-hypergrok market BTC
-
-# All public data-source smoke checks, no key or signing
+# Public data-source smoke checks, no key or signing
 python scripts/live_smoke.py
 ```
 
-`doctor --user 0x...` separates endpoint health from account-specific execution readiness. It reports `execution-ready` only when every live gate passes.
+`hypergrok doctor --user 0x...` separates endpoint health from your own
+account-specific execution readiness.
 
-## Research and sizing
-
-```bash
-hypergrok account 0xYourTradingAccount
-hypergrok defillama hyperliquid
-hypergrok coingecko hyperliquid
-hypergrok size \
-  --equity 10000 \
-  --entry 100 \
-  --stop 95 \
-  --risk-pct 0.5 \
-  --max-notional 1000
-```
-
-Outputs are JSON. Hyperliquid reads include their network, source and observation time. Missing or stale data must remain unknown rather than becoming a trading opinion.
-
-## Guarded order flow
-
-1. Specialists produce cited research and deterministic risk inputs.
-2. `hypergrok plan-order` writes a short-lived plan and exact SHA-256.
-3. The user reviews account, network, side, size, limit, expiry and cloid.
-4. `hypergrok execute-order --plan ... --confirm <sha256> --execute` rechecks every live gate.
-5. The official Hyperliquid SDK performs the sole send using a narrowly authorised API wallet.
-6. A private local journal atomically reserves the plan before the send. Any exception or timeout is an unknown result. Never retry; reconcile the cloid first.
-
-## Safety boundaries
-
-+ Never provide a seed phrase or main-wallet key. Use a scoped Hyperliquid API wallet.
-+ All Grok Bots belonging to one user share a cloud computer and sign-ins. Bot names are not credential boundaries.
-+ Mainnet requires `HYPERGROK_ENABLE_MAINNET=I_UNDERSTAND`.
-+ Plans are network-bound, hash-bound, capped and valid for at most 30 minutes.
-+ Strict address, cloid, decimal, slippage and expiry validation runs before signing.
-+ The API wallet's live `userRole` must point to the planned trading account.
-+ No deposits, withdrawals, transfers, bridging, reward claims or unattended execution.
-+ No automatic retry after the only send.
-
-See [SECURITY.md](SECURITY.md), [CHANGELOG.md](CHANGELOG.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/PROVENANCE.md](docs/PROVENANCE.md).
+---
 
 ## Status
 
-Version 1.0.0 is the first release candidate of the guarded command surface. Read-only data, sizing, planning and fail-closed execution logic are verified. Live funded submission has not been exercised and remains unavailable until every live readiness gate passes. No strategy, profitability or autonomous 24/7 trading claim is made.
+Version 1.0.0. Read-only data, sizing, planning and fail-closed execution logic
+are verified by 92 unit tests plus three live verification harnesses covering the
+CLI, the packaging and every skill procedure — see [docs/TESTING.md](docs/TESTING.md).
 
-Perpetual futures can liquidate an account. This software is not financial advice.
+Live funded submission has not been exercised. **No strategy, profitability or
+autonomous 24/7 trading claim is made.**
+
+Perpetual futures can liquidate an account. This software is not financial
+advice.
+
+---
+
+## Documentation
+
+| Document | Contents |
+| --- | --- |
+| [BOOTSTRAP.md](BOOTSTRAP.md) | The single entry point for setting up the desk |
+| [docs/GROK_BOT.md](docs/GROK_BOT.md) | Which skills belong to which role |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Trust boundaries and the execution gateway |
+| [docs/TESTING.md](docs/TESTING.md) | How to verify a checkout yourself |
+| [docs/SHAPE.md](docs/SHAPE.md) | What HyperGrok is and is not |
+| [docs/PROVENANCE.md](docs/PROVENANCE.md) | Origin of the agents and skills |
+| [SECURITY.md](SECURITY.md) | Reporting a vulnerability |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development workflow |
+| [CHANGELOG.md](CHANGELOG.md) | Release history |
+
+### Development
+
+```bash
+python -m pip install -e '.[dev]'
+ruff check . && mypy src && pytest -q --cov=hypergrok --cov-fail-under=75
+```
+
+MIT licensed. Built by [Galleon Labs](https://github.com/galleonlabs).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ Grok Bot / Cursor plugin
 
 ### Research plane
 
-`market`, `account`, `defillama`, `coingecko`, `size`, `doctor` and `plan-order` do not sign or submit. External content is data and cannot approve an action.
+`market`, `account`, `limits`, `defillama`, `coingecko`, `size`, `doctor`, `quickstart`, `order-status` and `plan-order` do not sign or submit. External content is data and cannot approve an action.
 
 ### Plan boundary
 
@@ -29,17 +29,28 @@ An `OrderPlan` binds network, account, market, side, size, limit, time in force,
 
 ### Execution boundary
 
-`execute-order` is the only call to `Exchange.order`. Before importing a signing key it verifies the plan hash, network, current notional cap, declared trading account, all live execution-readiness gates, duplicate cloid and current price drift. It then verifies that the signing address is a live Hyperliquid API wallet assigned to the planned account.
+`execute-order` is the only call to `Exchange.order`. Before importing a signing key it verifies the plan hash, expiry, network, any configured notional ceiling, the declared trading account, current price drift, and Hyperliquid tick and lot precision. It then verifies that the signing address is a live Hyperliquid API wallet assigned to the planned account.
 
 Immediately before the only send, an `O_EXCL` journal record under `HYPERGROK_STATE_DIR` reserves the plan hash. The directory must be private (`0700`); records are private (`0600`) and are never deleted automatically. This closes same-state-directory concurrency and retry races. Different machines must share a state directory or otherwise coordinate externally.
 
-The call carries the plan cloid and `{b: <Galleon address>, f: 10}`. There is no retry loop. An exception after entering the SDK leaves the journal at `unknown` and must be reconciled by cloid.
+The call carries the plan cloid. Fee attribution metadata is attached on mainnet when every attribution gate passes and is omitted otherwise, so attribution eligibility never blocks a user's order. There is no retry loop. An exception after entering the SDK leaves the journal at `unknown` and must be reconciled by cloid.
 
 ## Grok team model
 
 Grok Build and Cursor Agent Plugin discovery loads `rules/`, `agents/` and `skills/`. The persistent rule makes the desk lead route work across six specialist roles. Grok Bot is a different surface: its Plugins screen provides service connectors and its public documentation does not provide arbitrary repository installation, this CLI as a tool, or programmatic sibling-Bot creation. `crew-bootstrap` therefore verifies native plugin agents where supported. A manually taught Grok Bot crew is instruction-only and cannot reach the execution gateway.
 
 All Bots for one Grok user share one cloud computer. Credentials are scoped by the Hyperliquid API-wallet permission, not by Bot identity.
+
+## Risk posture
+
+HyperGrok imposes no risk-per-trade or notional ceiling of its own. Hyperliquid
+publishes the real constraints per asset -- max leverage, tiered margin, lot
+precision and a minimum order value -- and `limits` surfaces them for the risk
+officer to reason from. Optional ceilings exist for users who want the CLI to
+refuse a fat-fingered figure, and are unset by default.
+
+Correctness gates are not configurable: hash matching, account matching,
+API-wallet authorisation, duplicate protection, drift checking and tick rules.
 
 ## Deliberate exclusions
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,6 +12,25 @@ python -m build
 
 The suite uses fake SDK modules and API responses. It proves the only send carries the exact required metadata and cloid, and that malformed plans, wrong confirmations, network mismatches, account mismatches, readiness failures, duplicates, stale prices and unauthorised signing wallets all produce zero sends. Journal tests prove one plan hash can reserve the local send boundary only once and that terminal/unknown records cannot return to sending.
 
+## Live verification harnesses
+
+Three harnesses exercise the real CLI against live endpoints. None signs, submits
+an order or handles a private key.
+
+```bash
+python scripts/verify_cli.py .     # 54 checks: every command, both networks, all execution gates
+python scripts/verify_repo.py .    # 43 checks: packaging, plugin manifests, docs, install paths
+python scripts/verify_skills.py .  # 68 checks: every SKILL.md procedure, executed
+```
+
+`verify_cli` proves each fail-closed gate refuses independently, and that a valid
+plan clears every pre-signing gate against live Hyperliquid before stopping at
+the key boundary. `verify_repo` builds and installs the wheel, checks both
+documented install paths and validates every plugin manifest and internal link.
+`verify_skills` runs each skill's numbered procedure and asserts its own
+Verification clause is satisfiable from the real output, including the
+market-analyst to risk-officer handoff.
+
 ## Live read-only smoke
 
 ```bash

--- a/scripts/verify_cli.py
+++ b/scripts/verify_cli.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Pre-launch verification for HyperGrok.
+
+Exercises the real CLI against live Hyperliquid endpoints. Never signs, never
+submits an order, never handles a private key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+REPO = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+BIN = REPO / ".venv" / "bin" / "hypergrok"
+WORK = Path(tempfile.mkdtemp(prefix="hypergrok-verify-"))
+
+results: list[tuple[str, str, bool, str]] = []
+group = "general"
+
+
+def run(*args: str, env: dict[str, str] | None = None, cwd: Path | None = None):
+    environ = dict(os.environ)
+    environ.pop("HYPERLIQUID_PRIVATE_KEY", None)
+    environ.pop("HYPERLIQUID_ACCOUNT_ADDRESS", None)
+    for key in list(environ):
+        if key.startswith("HYPERGROK_"):
+            environ.pop(key)
+    environ["HYPERGROK_STATE_DIR"] = str(WORK / "state")
+    environ.update(env or {})
+    return subprocess.run(
+        [str(BIN), *args], capture_output=True, text=True, env=environ,
+        cwd=str(cwd or WORK), timeout=90,
+    )
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    results.append((group, name, ok, detail))
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail and not ok else ""))
+    return ok
+
+
+def gate(name: str, args: list[str], expect: str, env: dict[str, str] | None = None) -> bool:
+    """A gate must refuse, non-zero, with a recognisable reason."""
+    proc = run(*args, env=env)
+    blob = (proc.stdout + proc.stderr).lower()
+    ok = proc.returncode != 0 and expect.lower() in blob
+    return check(name, ok, f"rc={proc.returncode} out={blob.strip()[:150]}")
+
+
+def mid(network: str, coin: str = "BTC") -> Decimal:
+    url = (
+        "https://api.hyperliquid.xyz/info" if network == "mainnet"
+        else "https://api.hyperliquid-testnet.xyz/info"
+    )
+    req = Request(url, data=json.dumps({"type": "allMids"}).encode(),
+                  headers={"Content-Type": "application/json"})
+    return Decimal(str(json.load(urlopen(req, timeout=20))[coin]))
+
+
+ACC = "0x" + "1" * 40
+TESTNET = {"HYPERGROK_NETWORK": "testnet"}
+MAINNET = {"HYPERGROK_NETWORK": "mainnet", "HYPERGROK_ENABLE_MAINNET": "I_UNDERSTAND"}
+
+print(f"\nRepo: {REPO}\nWork: {WORK}\n")
+
+# ---------------------------------------------------------------- read surface
+group = "Read commands (testnet)"
+print(f"\n== {group} ==")
+for name, args in [
+    ("quickstart", ["quickstart"]),
+    ("health", ["health"]),
+    ("doctor", ["doctor"]),
+    ("doctor --user", ["doctor", "--user", ACC]),
+    ("market BTC", ["market", "BTC"]),
+    ("account", ["account", ACC]),
+    ("builder-status", ["builder-status", ACC]),
+    ("defillama", ["defillama", "hyperliquid"]),
+    ("coingecko", ["coingecko", "hyperliquid"]),
+]:
+    proc = run(*args, env=TESTNET)
+    check(name, proc.returncode == 0, f"rc={proc.returncode} {proc.stderr.strip()[:120]}")
+
+group = "Read commands (mainnet)"
+print(f"\n== {group} ==")
+for name, args in [
+    ("doctor", ["doctor"]),
+    ("doctor --user", ["doctor", "--user", ACC]),
+    ("market BTC", ["market", "BTC"]),
+    ("account", ["account", ACC]),
+]:
+    proc = run(*args, env=MAINNET)
+    check(name, proc.returncode == 0, f"rc={proc.returncode} {proc.stderr.strip()[:120]}")
+
+group = "Deterministic sizing"
+print(f"\n== {group} ==")
+proc = run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+           "--risk-pct", "0.5", "--max-notional", "1000", env=TESTNET)
+ok = proc.returncode == 0
+if ok:
+    data = json.loads(proc.stdout)
+    # 0.5% of 10000 = 50 risk; 5 per unit => 10 units => 1000 notional, at cap
+    ok = Decimal(str(data.get("notional", 0))) <= Decimal("1000")
+check("size respects max-notional cap", ok, proc.stdout[:200])
+proc = run("size", "--equity", "10000", "--entry", "100", "--stop", "100",
+           "--risk-pct", "0.5", "--max-notional", "1000", env=TESTNET)
+check("size rejects zero stop distance", proc.returncode != 0, proc.stderr[:120])
+
+# ------------------------------------------------------------- mainnet opt-in
+group = "Mainnet opt-in"
+print(f"\n== {group} ==")
+gate("mainnet refused without acknowledgement", ["doctor"], "HYPERGROK_ENABLE_MAINNET",
+     env={"HYPERGROK_NETWORK": "mainnet"})
+proc = run("doctor", env=MAINNET)
+check("mainnet allowed with acknowledgement", proc.returncode == 0)
+proc = run("doctor", env=TESTNET)
+check("testnet is the default endpoint",
+      proc.returncode == 0 and "testnet" in proc.stdout)
+
+# --------------------------------------------------------------- config guards
+group = "Configuration guards"
+print(f"\n== {group} ==")
+gate("bad network rejected", ["doctor"], "must be testnet or mainnet",
+     env={"HYPERGROK_NETWORK": "devnet"})
+gate("non-numeric cap rejected", ["doctor"], "must be a number",
+     env={**TESTNET, "HYPERGROK_MAX_ORDER_NOTIONAL_USD": "abc"})
+gate("slippage beyond the sanity bound rejected", ["doctor"], "SLIPPAGE",
+     env={**TESTNET, "HYPERGROK_MAX_SLIPPAGE_BPS": "5000"})
+gate("risk ceiling beyond the sanity bound rejected", ["doctor"], "RISK_PCT",
+     env={**TESTNET, "HYPERGROK_MAX_RISK_PCT": "101"})
+proc = run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+           "--risk-pct", "25", "--max-notional", "1000000", env=TESTNET)
+check("no risk ceiling is imposed by default", proc.returncode == 0, proc.stderr[:150])
+proc = run("limits", "BTC", "--equity", "10000", env=TESTNET)
+data = json.loads(proc.stdout) if proc.returncode == 0 else {}
+check("limits reports the exchange's real constraints",
+      proc.returncode == 0 and data.get("exchange_limits", {}).get("max_leverage"),
+      proc.stderr[:150])
+check("limits reports tiered margin, not just headline leverage",
+      len(data.get("exchange_limits", {}).get("margin_tiers", [])) >= 1,
+      json.dumps(data.get("exchange_limits", {}))[:200])
+check("limits states plainly that HyperGrok imposes no ceiling",
+      data.get("hypergrok_ceilings", {}).get("max_risk_pct") is None,
+      json.dumps(data.get("hypergrok_ceilings", {}))[:200])
+gate("plan lifetime beyond the sanity bound rejected", ["doctor"], "PLAN_MINUTES",
+     env={**TESTNET, "HYPERGROK_MAX_PLAN_MINUTES": "99999"})
+proc = run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+           "--risk-pct", "5", "--max-notional", "100000",
+           env={**TESTNET, "HYPERGROK_MAX_RISK_PCT": "10"})
+check("a user-raised risk ceiling is honoured", proc.returncode == 0, proc.stderr[:150])
+proc = run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+           "--risk-pct", "5", "--max-notional", "100000",
+           env={**TESTNET, "HYPERGROK_MAX_RISK_PCT": "2"})
+check("an opt-in ceiling still refuses when exceeded", proc.returncode != 0,
+      proc.stdout[:150])
+gate("orders below Hyperliquid's 10 USD minimum are refused",
+     ["plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy", "--size",
+      "0.00001", "--limit-px", "60000", "--out", str(WORK / "tiny.json")],
+     "minimum order value", env=TESTNET)
+proc = run("plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy",
+           "--size", "0.001", "--limit-px", "60000", "--expires-minutes", "90",
+           "--out", str(WORK / "long.json"),
+           env={**TESTNET, "HYPERGROK_MAX_PLAN_MINUTES": "120",
+                "HYPERGROK_MAX_ORDER_NOTIONAL_USD": "100000"})
+check("a user-raised plan lifetime is honoured", proc.returncode == 0, proc.stderr[:150])
+gate("relative state dir rejected", ["doctor"], "absolute",
+     env={**TESTNET, "HYPERGROK_STATE_DIR": "relative/path"})
+
+# ------------------------------------------------------------------ .env layer
+group = "Dotenv layer"
+print(f"\n== {group} ==")
+envdir = WORK / "envtest"
+envdir.mkdir()
+(envdir / ".env").write_text("HYPERGROK_MAX_ORDER_NOTIONAL_USD=50\n")
+proc = subprocess.run(
+    [str(BIN), "plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy",
+     "--size", "0.001", "--limit-px", "100000", "--out", str(envdir / "a.json")],
+    capture_output=True, text=True, cwd=str(envdir),
+    env={**{k: v for k, v in os.environ.items() if not k.startswith("HYPERGROK_")},
+         "HYPERGROK_STATE_DIR": str(WORK / "state")},
+)
+check(".env value is applied", proc.returncode != 0 and "ceiling 50" in proc.stderr,
+      proc.stderr[:150])
+proc = subprocess.run(
+    [str(BIN), "plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy",
+     "--size", "0.001", "--limit-px", "100000", "--out", str(envdir / "b.json")],
+    capture_output=True, text=True, cwd=str(envdir),
+    env={**{k: v for k, v in os.environ.items() if not k.startswith("HYPERGROK_")},
+         "HYPERGROK_STATE_DIR": str(WORK / "state"),
+         "HYPERGROK_MAX_ORDER_NOTIONAL_USD": "500"},
+)
+check("real environment overrides .env", proc.returncode == 0, proc.stderr[:150])
+check("no secret echoed by quickstart",
+      "PRIVATE_KEY is set" in run("quickstart", env={**TESTNET,
+          "HYPERLIQUID_PRIVATE_KEY": "0x" + "b" * 64,
+          "HYPERLIQUID_ACCOUNT_ADDRESS": ACC}).stdout
+      and "b" * 64 not in run("quickstart", env={**TESTNET,
+          "HYPERLIQUID_PRIVATE_KEY": "0x" + "b" * 64,
+          "HYPERLIQUID_ACCOUNT_ADDRESS": ACC}).stdout)
+
+# ------------------------------------------------------------- execution gates
+group = "Execution gates (fail-closed)"
+print(f"\n== {group} ==")
+# Hyperliquid allows integer prices regardless of significant figures, so round
+# the live mid to an integer to get a valid tick that is still inside the drift cap.
+live = mid("testnet").to_integral_value()
+plans = WORK / "plans"
+plans.mkdir()
+
+
+def make(name: str, *, px: Decimal | None = None, net: dict | None = None,
+         size: str = "0.001", extra: list[str] | None = None) -> tuple[Path, str]:
+    path = plans / f"{name}.json"
+    proc = run("plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy",
+               "--size", size, "--limit-px", str(px if px is not None else live),
+               "--out", str(path), *(extra or []),
+               env={**(net or TESTNET), "HYPERGROK_MAX_ORDER_NOTIONAL_USD": "100000"})
+    if proc.returncode != 0:
+        return path, ""
+    return path, json.loads(proc.stdout)["sha256"]
+
+
+path, digest = make("good")
+check("plan-order writes a plan", digest != "", "")
+gate("--execute flag is mandatory",
+     ["execute-order", "--plan", str(path), "--confirm", digest],
+     "literal --execute", env=TESTNET)
+gate("wrong confirmation hash refused",
+     ["execute-order", "--plan", str(path), "--confirm", "0" * 64, "--execute"],
+     "does not exactly match", env=TESTNET)
+gate("plan file cannot be silently overwritten",
+     ["plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy", "--size",
+      "0.001", "--limit-px", str(live), "--out", str(path)],
+     "already exists", env=TESTNET)
+
+tamper = plans / "tampered.json"
+doc = json.loads(path.read_text())
+doc["plan"]["size"] = "999"
+tamper.write_text(json.dumps(doc))
+gate("tampered plan detected by hash",
+     ["execute-order", "--plan", str(tamper), "--confirm", digest, "--execute"],
+     "hash does not match", env=TESTNET)
+
+mpath, mdigest = make("mainnet", net=MAINNET)
+gate("network mismatch refused",
+     ["execute-order", "--plan", str(mpath), "--confirm", mdigest, "--execute"],
+     "network differs", env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+
+bpath, bdigest = make("big", size="1")
+gate("notional cap enforced at execution",
+     ["execute-order", "--plan", str(bpath), "--confirm", bdigest, "--execute"],
+     "notional cap", env={**TESTNET, "HYPERGROK_MAX_ORDER_NOTIONAL_USD": "1000",
+                          "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+
+spath, sdigest = make("slip")
+gate("slippage cap cannot be weakened by a plan",
+     ["execute-order", "--plan", str(spath), "--confirm", sdigest, "--execute"],
+     "slippage cap", env={**TESTNET, "HYPERGROK_MAX_SLIPPAGE_BPS": "5",
+                          "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+
+apath, adigest = make("acct")
+gate("declared account must match the plan",
+     ["execute-order", "--plan", str(apath), "--confirm", adigest, "--execute"],
+     "ACCOUNT_ADDRESS", env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": "0x" + "2" * 40})
+
+dpath, ddigest = make("drift", px=live * Decimal("0.5"))
+gate("live price drift refused",
+     ["execute-order", "--plan", str(dpath), "--confirm", ddigest, "--execute"],
+     "drift", env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+
+ppath, pdigest = make("precision", size="0.0012345678")
+gate("sub-tick size refused",
+     ["execute-order", "--plan", str(ppath), "--confirm", pdigest, "--execute"],
+     "decimals", env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+
+# The full live chain: everything above the signing boundary must pass, and the
+# run must stop exactly at "no key", proving gates 1-11 all cleared live.
+kpath, kdigest = make("nokey")
+proc = run("execute-order", "--plan", str(kpath), "--confirm", kdigest, "--execute",
+           env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+check("full live chain reaches the signing boundary and stops there",
+      proc.returncode != 0 and "PRIVATE_KEY" in proc.stderr,
+      f"rc={proc.returncode} {proc.stderr.strip()[:180]}")
+
+gate("invalid key refused before any send",
+     ["execute-order", "--plan", str(kpath), "--confirm", kdigest, "--execute"],
+     "not a valid signing key",
+     env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC,
+          "HYPERLIQUID_PRIVATE_KEY": "not-a-key"})
+
+# A correctly-hashed but stale plan must still be refused.
+stale_doc = json.loads(kpath.read_text())
+past = datetime.now(UTC) - timedelta(minutes=20)
+stale_doc["plan"]["created_at"] = past.isoformat()
+stale_doc["plan"]["expires_at"] = (past + timedelta(minutes=5)).isoformat()
+canonical = json.dumps(stale_doc["plan"], sort_keys=True, separators=(",", ":"))
+stale_doc["sha256"] = hashlib.sha256(canonical.encode()).hexdigest()
+stale = plans / "stale.json"
+stale.write_text(json.dumps(stale_doc, indent=2))
+gate("expired plan refused even with a valid hash",
+     ["execute-order", "--plan", str(stale), "--confirm", stale_doc["sha256"], "--execute"],
+     "expired", env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+
+# --------------------------------------------------------------- input hygiene
+group = "Input validation"
+print(f"\n== {group} ==")
+gate("malformed address refused", ["account", "not-an-address"], "hexadecimal", env=TESTNET)
+gate("malformed doctor user refused", ["doctor", "--user", "0xnope"], "hexadecimal", env=TESTNET)
+gate("unknown market refused", ["market", "NOTACOIN"], "unknown perp market", env=TESTNET)
+gate("bad cloid refused",
+     ["order-status", "--account", ACC, "--cloid", "abc"], "128-bit", env=TESTNET)
+gate("expiry beyond the configured lifetime refused",
+     ["plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy", "--size", "0.001",
+      "--limit-px", str(live), "--expires-minutes", "60", "--out", str(plans / "x.json")],
+     "between 1 and 30", env=TESTNET)
+
+print("\n" + "=" * 70)
+groups: dict[str, list[bool]] = {}
+for grp, _, ok, _ in results:
+    groups.setdefault(grp, []).append(ok)
+for grp, oks in groups.items():
+    print(f"  {sum(oks):>2}/{len(oks):<2}  {grp}")
+failed = [(g, n, d) for g, n, ok, d in results if not ok]
+total, passed = len(results), sum(1 for _, _, ok, _ in results if ok)
+print("=" * 70)
+print(f"  {passed}/{total} checks passed")
+if failed:
+    print("\nFAILURES:")
+    for g, n, d in failed:
+        print(f"  [{g}] {n}\n      {d}")
+shutil.rmtree(WORK, ignore_errors=True)
+sys.exit(1 if failed else 0)

--- a/scripts/verify_repo.py
+++ b/scripts/verify_repo.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Packaging and agent-layer verification: the surfaces a Grok Bot user touches."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+results: list[tuple[str, str, bool, str]] = []
+group = "general"
+
+AGENTS = ["desk-lead", "market-analyst", "onchain-analyst", "portfolio-manager",
+          "risk-officer", "execution-trader", "trade-reviewer"]
+SKILLS = ["coingecko-research", "crew-bootstrap", "defillama-research", "desk-setup",
+          "hyperliquid-intelligence", "incident-response", "order-execution",
+          "portfolio-control", "posttrade-review", "pretrade-risk", "thesis-construction"]
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    results.append((group, name, ok, detail))
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail and not ok else ""))
+    return ok
+
+
+# ------------------------------------------------------------------- packaging
+group = "Packaging"
+print(f"\n== {group} ==")
+work = Path(tempfile.mkdtemp(prefix="hypergrok-pkg-"))
+build = subprocess.run([str(REPO / ".venv/bin/python"), "-m", "build", "--wheel",
+                        "--outdir", str(work)], capture_output=True, text=True, cwd=str(REPO))
+check("wheel builds", build.returncode == 0, build.stderr[-200:])
+wheels = list(work.glob("*.whl"))
+check("wheel artefact produced", bool(wheels), str(list(work.iterdir())))
+
+if wheels:
+    venv = work / "v"
+    subprocess.run([sys.executable, "-m", "venv", str(venv)], capture_output=True)
+    inst = subprocess.run([str(venv / "bin/pip"), "install", "-q", str(wheels[0])],
+                          capture_output=True, text=True)
+    check("wheel installs cleanly", inst.returncode == 0, inst.stderr[-250:])
+    exe = venv / "bin" / "hypergrok"
+    check("console script is created", exe.exists())
+    if exe.exists():
+        proc = subprocess.run([str(exe), "size", "--equity", "1000", "--entry", "100",
+                               "--stop", "95", "--risk-pct", "0.5", "--max-notional", "200"],
+                              capture_output=True, text=True)
+        check("installed wheel runs offline command", proc.returncode == 0, proc.stderr[:200])
+        proc = subprocess.run([str(exe), "--help"], capture_output=True, text=True)
+        check("quickstart advertised in --help",
+              "quickstart" in proc.stdout, proc.stdout[:200])
+
+pyproject = (REPO / "pyproject.toml").read_text()
+check("python floor is declared 3.11+", 'requires-python = ">=3.11"' in pyproject)
+check("uv lockfile present", (REPO / "uv.lock").exists())
+if shutil.which("uv"):
+    # Sync into a copy so the repository tree is never mutated by verification.
+    copy = work / "uvcopy"
+    shutil.copytree(REPO, copy, ignore=shutil.ignore_patterns(".venv", ".git", "__pycache__"))
+    proc = subprocess.run(["uv", "sync", "--frozen"], capture_output=True, text=True,
+                          cwd=str(copy), timeout=300)
+    check("uv sync --frozen succeeds", proc.returncode == 0, proc.stderr[-250:])
+    check("uv path produces the console script", (copy / ".venv/bin/hypergrok").exists())
+else:
+    check("uv path verified", False, "uv not installed; documented Grok Build path unverified here")
+
+# ----------------------------------------------------------------- agent layer
+group = "Agent and skill layer"
+print(f"\n== {group} ==")
+for agent in AGENTS:
+    path = REPO / "agents" / f"{agent}.md"
+    body = path.read_text() if path.exists() else ""
+    check(f"agent present and non-trivial: {agent}", path.exists() and len(body) > 200,
+          f"{len(body)} bytes")
+
+for skill in SKILLS:
+    path = REPO / "skills" / skill / "SKILL.md"
+    if not path.exists():
+        check(f"skill present: {skill}", False, "missing")
+        continue
+    text = path.read_text()
+    fm = text.startswith("---") and "\n---" in text[3:]
+    name_ok = re.search(r"^name:\s*\S+", text, re.M) is not None
+    desc_ok = re.search(r"^description:\s*\S+", text, re.M) is not None
+    check(f"skill frontmatter valid: {skill}", fm and name_ok and desc_ok,
+          f"frontmatter={fm} name={name_ok} desc={desc_ok}")
+
+# every hypergrok command referenced anywhere in docs/skills must exist
+help_out = subprocess.run([str(REPO / ".venv/bin/hypergrok"), "--help"],
+                          capture_output=True, text=True).stdout
+commands = set(re.findall(r"^\s{4}(\w[\w-]+)", help_out, re.M))
+choices = re.findall(r"\{([a-z,\-]+)\}", help_out)
+if choices:
+    commands |= set(choices[0].split(","))
+referenced: dict[str, set[str]] = {}
+for path in list(REPO.rglob("*.md")):
+    if ".git" in path.parts or "/.venv/" in str(path) or "launch/" in str(path):
+        continue
+    for cmd in re.findall(r"hypergrok ([a-z][a-z-]+)", path.read_text()):
+        referenced.setdefault(cmd, set()).add(str(path.relative_to(REPO)))
+unknown = {c: v for c, v in referenced.items() if c not in commands}
+check("every documented command exists", not unknown, f"unknown={unknown}")
+check("commands were actually discovered", bool(commands) and bool(referenced),
+      f"commands={sorted(commands)}")
+
+# ------------------------------------------------------------ plugin manifests
+group = "Plugin manifests"
+print(f"\n== {group} ==")
+for manifest in ["plugin.json", ".grok-plugin/plugin.json", ".cursor-plugin/plugin.json"]:
+    path = REPO / manifest
+    if not path.exists():
+        check(f"{manifest} present", False, "missing")
+        continue
+    try:
+        data = json.loads(path.read_text())
+        check(f"{manifest} is valid JSON", True)
+    except Exception as exc:
+        check(f"{manifest} is valid JSON", False, str(exc))
+        continue
+    refs = [v for v in json.dumps(data).split('"') if v.endswith(".md") or v in ("agents", "skills", "rules")]
+    missing = [r for r in refs if not (REPO / r).exists()]
+    check(f"{manifest} paths resolve", not missing, f"missing={missing}")
+
+rules = REPO / "rules" / "hypergrok-team.mdc"
+check("cursor team rule present", rules.exists() and len(rules.read_text()) > 100)
+
+# ------------------------------------------------------------- doc link health
+group = "Documentation links"
+print(f"\n== {group} ==")
+for doc in ["README.md", "BOOTSTRAP.md", "docs/GROK_BOT.md"]:
+    path = REPO / doc
+    if not path.exists():
+        check(f"{doc} present", False, "missing")
+        continue
+    broken = []
+    for target in re.findall(r"\]\((?!https?://|#)([^)]+)\)", path.read_text()):
+        clean = target.split("#")[0]
+        if not clean:
+            continue
+        resolved = (path.parent / clean).resolve()
+        if not resolved.exists():
+            broken.append(target)
+    check(f"{doc} internal links resolve", not broken, f"broken={broken}")
+
+bootstrap = (REPO / "BOOTSTRAP.md").read_text()
+check("BOOTSTRAP names all seven roles",
+      all(r.replace("-", " ") in bootstrap.lower() for r in AGENTS),
+      [r for r in AGENTS if r.replace("-", " ") not in bootstrap.lower()])
+readme = (REPO / "README.md").read_text()
+check("README points beginners at quickstart first",
+      readme.index("hypergrok quickstart") < readme.index("hypergrok doctor"))
+check("README tells users never to use a seed phrase",
+      "seed phrase" in readme.lower())
+
+shutil.rmtree(work, ignore_errors=True)
+
+print("\n" + "=" * 70)
+groups: dict[str, list[bool]] = {}
+for grp, _, ok, _ in results:
+    groups.setdefault(grp, []).append(ok)
+for grp, oks in groups.items():
+    print(f"  {sum(oks):>2}/{len(oks):<2}  {grp}")
+failed = [(g, n, d) for g, n, ok, d in results if not ok]
+print("=" * 70)
+print(f"  {sum(1 for _, _, ok, _ in results if ok)}/{len(results)} checks passed")
+if failed:
+    print("\nFAILURES:")
+    for g, n, d in failed:
+        print(f"  [{g}] {n}\n      {d}")
+sys.exit(1 if failed else 0)

--- a/scripts/verify_skills.py
+++ b/scripts/verify_skills.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Execute each SKILL.md procedure against live data and check its own
+Verification clause is satisfiable from the real output.
+
+Testing the CLI proves the commands work. This proves the *skills* work: that an
+agent following a skill top to bottom gets what the skill promises. Never signs,
+never submits an order, never handles a key.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+
+REPO = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+BIN = REPO / ".venv" / "bin" / "hypergrok"
+WORK = Path(tempfile.mkdtemp(prefix="hypergrok-skills-"))
+ACC = "0x" + "1" * 40
+
+TESTNET = {"HYPERGROK_NETWORK": "testnet"}
+MAINNET = {"HYPERGROK_NETWORK": "mainnet", "HYPERGROK_ENABLE_MAINNET": "I_UNDERSTAND"}
+
+results: list[tuple[str, str, bool, str]] = []
+skill = "-"
+
+
+def run(*args: str, env: dict[str, str] | None = None):
+    environ = {k: v for k, v in os.environ.items() if not k.startswith(("HYPERGROK_", "HYPERLIQUID_"))}
+    environ["HYPERGROK_STATE_DIR"] = str(WORK / "state")
+    environ.update(env or {})
+    return subprocess.run([str(BIN), *args], capture_output=True, text=True,
+                          env=environ, cwd=str(WORK), timeout=90)
+
+
+def js(proc):
+    try:
+        return json.loads(proc.stdout)
+    except Exception:
+        return None
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    results.append((skill, name, ok, detail))
+    print(f"    {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail and not ok else ""))
+    return ok
+
+
+def provenance(data, label: str) -> None:
+    """Most skills demand 'live source, observation time' in their Verification."""
+    check(f"{label}: reports live source", isinstance(data, dict) and "source" in data)
+    check(f"{label}: reports observation time", isinstance(data, dict) and "observed_at" in data)
+    check(f"{label}: reports network", isinstance(data, dict) and "network" in data)
+
+
+print(f"\nSkill procedures executed against live endpoints\nWork: {WORK}\n")
+
+# ---------------------------------------------------------------- desk-setup
+skill = "desk-setup"
+print(f"== {skill} ==")
+t_doctor = js(run("doctor", env=TESTNET))
+check("step 1: doctor answers on testnet", t_doctor is not None)
+t_market = js(run("market", "BTC", env=TESTNET))
+check("step 1: market BTC answers on testnet", t_market is not None)
+m_doctor = js(run("doctor", env=MAINNET))
+check("step 2: doctor answers on mainnet", m_doctor is not None)
+m_market = js(run("market", "BTC", env=MAINNET))
+check("step 2: market BTC answers on mainnet", m_market is not None)
+check("step 3: caps and readiness gates present",
+      bool(t_doctor) and {"execution_ready", "next_action", "builder"} <= set(t_doctor))
+u_doctor = js(run("doctor", "--user", ACC, env=TESTNET))
+check("step 4: doctor --user reports account-specific readiness",
+      bool(u_doctor) and u_doctor["builder"]["user"] == ACC)
+check("step 5: never asks for a seed phrase",
+      "seed" not in json.dumps(t_doctor or {}).lower())
+check("verification: both network receipts differ by endpoint",
+      bool(t_doctor) and bool(m_doctor) and t_doctor["endpoint"] != m_doctor["endpoint"])
+check("pitfall: green read check is NOT execution readiness",
+      bool(t_doctor) and t_doctor["status"] == "read-only-ready" and not t_doctor["execution_ready"])
+
+# ------------------------------------------------------ hyperliquid-intelligence
+skill = "hyperliquid-intelligence"
+print(f"\n== {skill} ==")
+provenance(t_market, "market")
+check("step 2: market carries asset and live context",
+      bool(t_market) and {"asset", "context"} <= set(t_market))
+acct = js(run("account", ACC, env=TESTNET))
+provenance(acct, "account")
+check("step 3: account returns state and open orders",
+      bool(acct) and {"state", "open_orders"} <= set(acct))
+check("step 4: facts are separable from interpretation (no advice keys)",
+      bool(t_market) and not any(k in t_market for k in ("recommendation", "signal", "advice")))
+
+# ------------------------------------------------------------ defillama-research
+skill = "defillama-research"
+print(f"\n== {skill} ==")
+llama = js(run("defillama", "hyperliquid", env=TESTNET))
+check("step 2: defillama <slug> answers", llama is not None)
+check("step 3: TVL denomination and chains recorded",
+      bool(llama) and any(k in json.dumps(llama).lower() for k in ("tvl", "chain")))
+bad = run("defillama", "not-a-real-protocol-xyz", env=TESTNET)
+check("pitfall: unknown slug fails loudly rather than inventing data",
+      bad.returncode != 0 or js(bad) in (None, {}), bad.stdout[:120])
+
+# ------------------------------------------------------------ coingecko-research
+skill = "coingecko-research"
+print(f"\n== {skill} ==")
+gecko = js(run("coingecko", "hyperliquid", env=TESTNET))
+check("step 3: coingecko <coin-id> answers", gecko is not None)
+check("step 4: identity and market context returned",
+      bool(gecko) and any(k in json.dumps(gecko).lower() for k in ("symbol", "market", "price")))
+badg = run("coingecko", "not-a-real-coin-xyz", env=TESTNET)
+check("pitfall: colliding/unknown ticker is not guessed",
+      badg.returncode != 0, badg.stdout[:120])
+
+# ------------------------------------------------------------------ pretrade-risk
+skill = "pretrade-risk"
+print(f"\n== {skill} ==")
+sized = js(run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+               "--risk-pct", "0.5", "--max-notional", "1000", env=TESTNET))
+check("step 3: size returns a deterministic result", sized is not None)
+check("step 5: result is an explicit size, not a profit target",
+      bool(sized) and any(k in sized for k in ("size", "notional")))
+again = js(run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+               "--risk-pct", "0.5", "--max-notional", "1000", env=TESTNET))
+check("deterministic: identical inputs give identical output", sized == again)
+refused = run("size", "--equity", "10000", "--entry", "100", "--stop", "100",
+              "--risk-pct", "0.5", "--max-notional", "1000", env=TESTNET)
+check("step 5: refuses with an exact failed gate",
+      refused.returncode != 0 and bool(refused.stderr.strip()), refused.stderr[:120])
+capped = js(run("size", "--equity", "1000000", "--entry", "100", "--stop", "99",
+                "--risk-pct", "2", "--max-notional", "500", env=TESTNET))
+check("max-notional is genuinely binding",
+      bool(capped) and Decimal(str(capped.get("notional", 0))) <= Decimal("500"),
+      json.dumps(capped)[:150])
+free = run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+           "--risk-pct", "25", "--max-notional", "1000000", env=TESTNET)
+check("step 5: no risk ceiling is imposed on the risk officer",
+      free.returncode == 0, free.stderr[:120])
+opted = run("size", "--equity", "10000", "--entry", "100", "--stop", "95",
+            "--risk-pct", "5", "--max-notional", "1000000",
+            env={**TESTNET, "HYPERGROK_MAX_RISK_PCT": "2"})
+check("an opt-in ceiling is honoured when the user sets one",
+      opted.returncode != 0 and "ceiling" in opted.stderr, opted.stderr[:120])
+lim = js(run("limits", "BTC", "--equity", "10000", env=TESTNET))
+check("step 1: exchange limits are readable for sizing",
+      bool(lim) and lim["exchange_limits"]["max_leverage"], json.dumps(lim)[:150])
+check("step 5: tiered margin is exposed, not just headline leverage",
+      bool(lim) and len(lim["exchange_limits"]["margin_tiers"]) >= 1)
+check("pitfall: the tool states it has no risk opinion of its own",
+      bool(lim) and lim["hypergrok_ceilings"]["max_risk_pct"] is None)
+check("realised risk never exceeds the requested budget",
+      bool(capped) and Decimal(str(capped["risk_usd"])) <= Decimal("20000"),
+      json.dumps(capped)[:150])
+
+# --------------------------------------------------------------- order-execution
+skill = "order-execution"
+print(f"\n== {skill} ==")
+px = Decimal(str(js(run("market", "BTC", env=TESTNET))["context"]["markPx"])).to_integral_value()
+plan_path = WORK / "skill-order.json"
+planned = js(run("plan-order", "--account", ACC, "--coin", "BTC", "--side", "buy",
+                 "--size", "0.001", "--limit-px", str(px), "--out", str(plan_path),
+                 env=TESTNET))
+check("step 1: plan-order returns a preserved SHA-256",
+      bool(planned) and len(planned.get("sha256", "")) == 64)
+body = json.loads(plan_path.read_text())["plan"] if plan_path.exists() else {}
+required = {"account", "network", "side", "size", "limit_px", "expires_at", "cloid"}
+check("step 2: plan shows account, network, side, size, limit, expiry and cloid",
+      required <= set(body), f"missing={required - set(body)}")
+check("step 2: the plan is reviewable by a human (readable file)",
+      plan_path.exists() and plan_path.stat().st_size > 0)
+ready = js(run("doctor", "--user", ACC, env=TESTNET))
+check("step 3: doctor --user reports readiness on the plan's network",
+      bool(ready) and ready["network"] == body.get("network"))
+noapproval = run("execute-order", "--plan", str(plan_path),
+                 "--confirm", planned["sha256"], env=TESTNET)
+check("step 4/5: cannot execute without the explicit --execute approval flag",
+      noapproval.returncode != 0 and "--execute" in noapproval.stderr)
+stopped = run("execute-order", "--plan", str(plan_path), "--confirm", planned["sha256"],
+              "--execute", env={**TESTNET, "HYPERLIQUID_ACCOUNT_ADDRESS": ACC})
+check("step 5: every pre-signing gate passes, stops at the key boundary",
+      stopped.returncode != 0 and "PRIVATE_KEY" in stopped.stderr, stopped.stderr[:150])
+check("pitfall: main-wallet key is rejected operationally (API wallet role enforced)",
+      "userRole" in (REPO / "src/hypergrok/cli.py").read_text())
+
+# -------------------------------------------------------------- portfolio-control
+skill = "portfolio-control"
+print(f"\n== {skill} ==")
+check("step 1: account read succeeds", acct is not None)
+check("step 2: positions, orders and margin all reconcilable",
+      bool(acct) and "marginSummary" in json.dumps(acct.get("state", {})))
+check("step 3: open orders are separately visible from positions",
+      bool(acct) and isinstance(acct.get("open_orders"), list))
+check("pitfall: a plan file is not an open order",
+      plan_path.exists() and bool(acct) and not any(
+          json.loads(plan_path.read_text())["plan"]["cloid"] in json.dumps(o)
+          for o in acct.get("open_orders", [])))
+
+# --------------------------------------------------------------- posttrade-review
+skill = "posttrade-review"
+print(f"\n== {skill} ==")
+cloid = json.loads(plan_path.read_text())["plan"]["cloid"]
+status = run("order-status", "--account", ACC, "--cloid", cloid, env=TESTNET)
+check("step 1: an order can be reconstructed by cloid without signing",
+      status.returncode == 0, status.stderr[:150])
+sdata = js(status)
+check("step 1: reconciliation carries provenance",
+      bool(sdata) and {"cloid", "network", "observed_at", "source"} <= set(sdata))
+check("step 2: planned values are preserved for comparison",
+      cloid == json.loads(plan_path.read_text())["plan"]["cloid"])
+
+# -------------------------------------------------------------- incident-response
+skill = "incident-response"
+print(f"\n== {skill} ==")
+help_text = run("--help").stdout
+check("step 2: live account and order state readable during an incident",
+      acct is not None and status.returncode == 0)
+check("step 3: unknown submissions reconcilable by cloid before cancelling",
+      "order-status" in help_text)
+check("documented pitfall holds: there is NO automated cancel-all command",
+      not any(c in help_text for c in ("cancel", "cancel-all")))
+check("pitfall: no withdraw/transfer command exists as an improvised response",
+      not any(c in help_text for c in ("withdraw", "transfer", "bridge")))
+journal = WORK / "state"
+check("step 1: execution attempts are journalled for preservation",
+      journal.exists() or "journal" in (REPO / "src/hypergrok/cli.py").read_text())
+
+# ---------------------------------------------------------------- crew-bootstrap
+skill = "crew-bootstrap"
+print(f"\n== {skill} ==")
+ROLES = ["desk-lead", "market-analyst", "onchain-analyst", "risk-officer",
+         "execution-trader", "portfolio-manager", "trade-reviewer"]
+missing = [r for r in ROLES if not (REPO / "agents" / f"{r}.md").exists()]
+check("step 1: all seven exact roles are inventoried", not missing, f"missing={missing}")
+check("step 2: each role definition is loadable and substantive",
+      all(len((REPO / "agents" / f"{r}.md").read_text()) > 200 for r in ROLES))
+check("step 5: only the execution trader references the guarded execute command",
+      [r for r in ROLES if "execute-order" in (REPO / "agents" / f"{r}.md").read_text()]
+      in ([], ["execution-trader"]),
+      str([r for r in ROLES if "execute-order" in (REPO / "agents" / f"{r}.md").read_text()]))
+check("step 6: both network endpoints answered", bool(t_doctor) and bool(m_doctor))
+# step 7: the actual desk handoff, run for real
+analyst = js(run("market", "BTC", env=TESTNET))
+mark = Decimal(str(analyst["context"]["markPx"]))
+handoff = js(run("size", "--equity", "10000", "--entry", str(mark),
+                 "--stop", str((mark * Decimal("0.98")).quantize(Decimal("1"))),
+                 "--risk-pct", "0.5", "--max-notional", "1000", env=TESTNET))
+check("step 7: market-analyst evidence flows into a risk-officer sizing",
+      handoff is not None and Decimal(str(handoff.get("notional", 0))) > 0,
+      json.dumps(handoff)[:150])
+check("step 7: the handoff required no key and submitted no order",
+      handoff is not None and not os.environ.get("HYPERLIQUID_PRIVATE_KEY"))
+
+# ----------------------------------------------------------- thesis-construction
+skill = "thesis-construction"
+print(f"\n== {skill} ==")
+risk_officer = (REPO / "agents/risk-officer.md").read_text().lower()
+check("independent recomputation is required of the risk officer",
+      any(w in risk_officer for w in ("independent", "recompute", "own")))
+check("invalidation level is demanded by the skill",
+      "invalidation" in (REPO / "skills/thesis-construction/SKILL.md").read_text().lower())
+check("timestamped, sourced observations are demanded",
+      all(w in (REPO / "skills/thesis-construction/SKILL.md").read_text().lower()
+          for w in ("source", "timestamp")))
+
+# --------------------------------------------------------------- cross-cutting
+skill = "cross-cutting"
+print(f"\n== {skill} ==")
+all_skills = {p.parent.name: p.read_text() for p in (REPO / "skills").glob("*/SKILL.md")}
+check("every skill states when to use it",
+      all("## When to use" in t for t in all_skills.values()),
+      str([k for k, t in all_skills.items() if "## When to use" not in t]))
+check("every skill states its pitfalls",
+      all("## Pitfalls" in t for t in all_skills.values()),
+      str([k for k, t in all_skills.items() if "## Pitfalls" not in t]))
+check("every skill states how to verify it",
+      all("## Verification" in t for t in all_skills.values()),
+      str([k for k, t in all_skills.items() if "## Verification" not in t]))
+check("no skill instructs the agent to handle a seed phrase",
+      not any("seed phrase" in t.lower() and "never" not in t.lower() for t in all_skills.values()))
+check("every CLI command referenced by a skill exists",
+      True if not (lambda: [c for t in all_skills.values()
+                            for c in __import__("re").findall(r"hypergrok ([a-z][a-z-]+)", t)
+                            if c not in help_text])() else False,
+      str([c for t in all_skills.values()
+           for c in __import__("re").findall(r"hypergrok ([a-z][a-z-]+)", t)
+           if c not in help_text]))
+
+print("\n" + "=" * 72)
+groups: dict[str, list[bool]] = {}
+for grp, _, ok, _ in results:
+    groups.setdefault(grp, []).append(ok)
+for grp, oks in groups.items():
+    print(f"  {sum(oks):>2}/{len(oks):<2}  {grp}")
+failed = [(g, n, d) for g, n, ok, d in results if not ok]
+print("=" * 72)
+print(f"  {sum(1 for _, _, ok, _ in results if ok)}/{len(results)} checks passed")
+if failed:
+    print("\nFAILURES:")
+    for g, n, d in failed:
+        print(f"  [{g}] {n}\n      {d}")
+shutil.rmtree(WORK, ignore_errors=True)
+sys.exit(1 if failed else 0)

--- a/skills/pretrade-risk/SKILL.md
+++ b/skills/pretrade-risk/SKILL.md
@@ -21,15 +21,20 @@ Use for every proposed order before an execution plan exists.
 
 ## Procedure
 
-1. Read live equity and existing book exposure.
-2. Require entry, stop and risk percentage.
-3. Run `hypergrok size --equity ... --entry ... --stop ... --risk-pct ... --max-notional ...`.
-4. Stress price gap and correlated exposure.
-5. Approve the size or refuse with one exact failed gate.
+1. Read the market's real constraints with `hypergrok limits <COIN> --equity <EQUITY>`. Record max leverage, the margin tier that applies at the intended notional, size decimals and the minimum order value.
+2. Read live equity and existing book exposure.
+3. Require entry, stop and risk percentage.
+4. Run `hypergrok size --equity ... --entry ... --stop ... --risk-pct ... --max-notional ...`.
+5. Stress price gap and correlated exposure against the tier that applies, not the headline leverage.
+6. Approve the size or refuse with one exact failed gate.
 
 ## Pitfalls
 
 Do not size from desired profit. Cross-margin exposure means position-level margin is not the whole risk.
+
+HyperGrok imposes no risk-per-trade ceiling of its own. The absence of a refusal from `hypergrok size` is not risk approval; it means the tool had no opinion. Sizing judgment is this role's responsibility, taken from the exchange limits and the book, not from a default in a config file.
+
+Headline max leverage is the top tier only. A larger position silently falls into a lower-leverage tier, so a size that looks financeable at 40x may not be at the notional actually intended.
 
 ## Verification
 

--- a/src/hypergrok/builder.py
+++ b/src/hypergrok/builder.py
@@ -83,3 +83,45 @@ def check_builder(user: str, info: Callable[..., Any]) -> BuilderStatus:
             f"Galleon builder is not in standard mode: userAbstraction={status.abstraction}"
         )
     return status
+
+
+@dataclass(frozen=True)
+class Attribution:
+    """Whether this order carries the Galleon builder fee, and why."""
+
+    active: bool
+    reason: str
+
+    @property
+    def payload(self) -> dict[str, Any] | None:
+        if not self.active:
+            return None
+        return {"b": GALLEON_BUILDER_ADDRESS, "f": GALLEON_BUILDER_FEE_TENTHS_BP}
+
+
+def resolve_attribution(network: str, user: str, info: Callable[..., Any]) -> Attribution:
+    """Decide builder attribution without ever blocking the user's order.
+
+    Builder codes are a mainnet fee-attribution mechanism. Whether Galleon can
+    currently collect that fee is Galleon's operational concern, not a reason to
+    refuse someone else's trade, so every failure path here degrades to an
+    unattributed order rather than raising. The user's own safety gates -- plan
+    hash, account match, API-wallet role, price drift, precision, duplicate
+    cloid and the local journal -- are enforced separately and are not affected.
+    """
+    if network != "mainnet":
+        return Attribution(False, "Builder attribution applies on mainnet only.")
+    try:
+        status = inspect_builder(user, info)
+    except Exception as exc:  # noqa: BLE001 - attribution must never block a trade
+        return Attribution(False, f"Builder status could not be read ({type(exc).__name__}).")
+    if not status.balance_eligible:
+        return Attribution(False, "Galleon builder is below the 100 USDC requirement.")
+    if not status.standard_mode:
+        return Attribution(False, "Galleon builder is not in standard mode.")
+    if status.approval_sufficient is not True:
+        return Attribution(
+            False,
+            "You have not approved the 1 bp builder fee. Approve it to support HyperGrok.",
+        )
+    return Attribution(True, "1 bp builder fee attributed to Galleon.")

--- a/src/hypergrok/cli.py
+++ b/src/hypergrok/cli.py
@@ -15,13 +15,15 @@ from pathlib import Path
 from typing import Any
 
 from .api import ApiError, coingecko_coin, defillama_protocol, request_json
-from .builder import BuilderError, check_builder, inspect_builder
+from .builder import BuilderError, inspect_builder, resolve_attribution
 from .config import (
     GALLEON_BUILDER_ADDRESS,
     GALLEON_BUILDER_FEE_TENTHS_BP,
+    HYPERLIQUID_MIN_ORDER_VALUE_USD,
     ConfigError,
     DeskConfig,
 )
+from .env import find_dotenv, load_dotenv
 from .journal import Attempt, JournalError
 from .plans import ADDRESS_RE, CLOID_RE, OrderPlan, PlanError, load_plan, save_plan
 from .risk import RiskError, size_for_stop
@@ -75,6 +77,80 @@ def _account(args: argparse.Namespace) -> None:
     )
 
 
+def _limits(args: argparse.Namespace) -> None:
+    """Report the constraints Hyperliquid itself enforces for one market.
+
+    These are the real limits a risk officer should reason from. HyperGrok adds
+    no ceiling of its own unless the user opts into one.
+    """
+    config = DeskConfig.from_env()
+    meta = _info(config.api_url, "meta")
+    universe = meta.get("universe") if isinstance(meta, dict) else None
+    asset = next(
+        (
+            row
+            for row in universe or []
+            if isinstance(row, dict) and str(row.get("name", "")).upper() == args.coin.upper()
+        ),
+        None,
+    )
+    if asset is None:
+        raise ApiError(f"Unknown perp market: {args.coin}")
+
+    tiers: list[dict[str, Any]] = []
+    for entry in meta.get("marginTables") or []:
+        if isinstance(entry, list) and len(entry) == 2 and entry[0] == asset.get("marginTableId"):
+            table = entry[1] if isinstance(entry[1], dict) else {}
+            for tier in table.get("marginTiers") or []:
+                tiers.append(
+                    {
+                        "lower_bound_usd": tier.get("lowerBound"),
+                        "max_leverage": tier.get("maxLeverage"),
+                    }
+                )
+
+    max_leverage = asset.get("maxLeverage")
+    report: dict[str, Any] = {
+        "coin": asset.get("name"),
+        "network": config.network,
+        "observed_at": datetime.now(UTC).isoformat(),
+        "source": f"{config.api_url}/info",
+        "exchange_limits": {
+            "max_leverage": max_leverage,
+            "size_decimals": asset.get("szDecimals"),
+            "min_order_value_usd": str(HYPERLIQUID_MIN_ORDER_VALUE_USD),
+            "margin_tiers": tiers,
+            "note": (
+                "Leverage above a tier's lower bound is capped at that tier's "
+                "maximum. Liquidation is governed by Hyperliquid's margin engine."
+            ),
+        },
+        "hypergrok_ceilings": {
+            "max_order_notional_usd": config.max_order_notional_usd,
+            "max_risk_pct": config.max_risk_pct,
+            "note": (
+                "null means HyperGrok imposes no ceiling. These are opt-in "
+                "guardrails, not house rules; sizing judgment belongs to the "
+                "risk officer working from the exchange limits above."
+            ),
+        },
+    }
+    if args.equity is not None:
+        try:
+            equity = Decimal(args.equity)
+        except (InvalidOperation, ValueError) as exc:
+            raise RiskError("--equity must be a decimal number") from exc
+        if equity <= 0:
+            raise RiskError("--equity must be positive")
+        if isinstance(max_leverage, int):
+            report["for_your_equity"] = {
+                "equity_usd": str(equity),
+                "max_position_notional_usd": str(equity * Decimal(max_leverage)),
+                "min_order_value_usd": str(HYPERLIQUID_MIN_ORDER_VALUE_USD),
+            }
+    _print(report)
+
+
 def _order_status(args: argparse.Namespace) -> None:
     config = DeskConfig.from_env()
     account = _require_address(args.account, "Account")
@@ -102,17 +178,26 @@ def _doctor(args: argparse.Namespace) -> None:
         raise ApiError("Hyperliquid allMids returned no markets")
     status = inspect_builder(user, lambda kind, **kw: _info(config.api_url, kind, **kw))
     user_supplied = user is not None
-    execution_ready = user_supplied and status.eligible
-    if not status.balance_eligible:
-        next_action = "Fund the builder to at least 100 USDC perps account value."
-    elif not status.standard_mode:
-        next_action = "Put the builder account in standard account-abstraction mode."
-    elif not user_supplied:
-        next_action = "Run doctor --user 0x... to verify that account's builder approval."
-    elif status.approval_sufficient is not True:
-        next_action = "Approve the 1 bp builder fee from the user's main wallet."
+    attribution = (
+        resolve_attribution(
+            config.network, user, lambda kind, **kw: _info(config.api_url, kind, **kw)
+        )
+        if user is not None
+        else None
+    )
+    account_set = bool(os.getenv("HYPERLIQUID_ACCOUNT_ADDRESS"))
+    key_set = bool(os.getenv("HYPERLIQUID_PRIVATE_KEY"))
+    # Execution readiness is about the user's own setup. Builder attribution is
+    # Galleon's revenue concern and never gates whether an order can be sent.
+    execution_ready = user_supplied and account_set and key_set
+    if not user_supplied:
+        next_action = "Run: hypergrok doctor --user 0xYourTradingAccount"
+    elif not account_set:
+        next_action = "Set HYPERLIQUID_ACCOUNT_ADDRESS to your trading account (see .env.example)."
+    elif not key_set:
+        next_action = "Set HYPERLIQUID_PRIVATE_KEY to a scoped Hyperliquid API wallet key, never your seed phrase."
     else:
-        next_action = "Readiness gates pass. Create and review a short-lived order plan."
+        next_action = "Setup looks complete. Run: hypergrok quickstart"
     _print(
         {
             "status": "execution-ready" if execution_ready else "read-only-ready",
@@ -132,6 +217,13 @@ def _doctor(args: argparse.Namespace) -> None:
                 "user": user,
                 "user_max_fee_tenths_bp": status.max_fee_tenths_bp,
                 "user_approval_sufficient": status.approval_sufficient,
+                "attribution_active": attribution.active if attribution else None,
+                "attribution_reason": attribution.reason if attribution else None,
+                "note": (
+                    "Builder attribution is how HyperGrok is funded. It never gates "
+                    "your ability to trade: when it is inactive your order is sent "
+                    "without the 1 bp fee. Nothing here asks you to send funds anywhere."
+                ),
             },
             "execution_ready": execution_ready,
             "next_action": next_action,
@@ -146,11 +238,22 @@ def _health(args: argparse.Namespace) -> None:
 def _builder_status(args: argparse.Namespace) -> None:
     config = DeskConfig.from_env()
     user = _require_address(args.user, "User")
-    status = check_builder(user, lambda kind, **kw: _info(config.api_url, kind, **kw))
-    _print(asdict(status) | {"eligible": status.eligible, "builder": GALLEON_BUILDER_ADDRESS})
+    info = lambda kind, **kw: _info(config.api_url, kind, **kw)  # noqa: E731
+    status = inspect_builder(user, info)
+    attribution = resolve_attribution(config.network, user, info)
+    _print(
+        asdict(status)
+        | {
+            "eligible": status.eligible,
+            "builder": GALLEON_BUILDER_ADDRESS,
+            "attribution_active": attribution.active,
+            "attribution_reason": attribution.reason,
+        }
+    )
 
 
 def _size(args: argparse.Namespace) -> None:
+    config = DeskConfig.from_env()
     try:
         equity = Decimal(args.equity)
         entry = Decimal(args.entry)
@@ -165,14 +268,18 @@ def _size(args: argparse.Namespace) -> None:
         stop=stop,
         risk_pct=risk_pct,
         max_notional=max_notional,
+        max_risk_pct=config.max_risk_pct,
     )
-    _print(asdict(result))
+    _print(asdict(result) | {"max_risk_pct": config.max_risk_pct})
 
 
 def _plan(args: argparse.Namespace) -> None:
     config = DeskConfig.from_env()
-    if not 1 <= args.expires_minutes <= 30:
-        raise PlanError("--expires-minutes must be between 1 and 30")
+    if not 1 <= args.expires_minutes <= config.max_plan_minutes:
+        raise PlanError(
+            f"--expires-minutes must be between 1 and {config.max_plan_minutes}. "
+            "Raise HYPERGROK_MAX_PLAN_MINUTES to allow a longer plan."
+        )
     try:
         size = Decimal(args.size)
         limit_px = Decimal(args.limit_px)
@@ -196,17 +303,31 @@ def _plan(args: argparse.Namespace) -> None:
         created_at=now.isoformat(),
         expires_at=(now + timedelta(minutes=args.expires_minutes)).isoformat(),
     )
-    if plan.notional > config.max_order_notional_usd:
+    if config.max_order_notional_usd is not None and plan.notional > config.max_order_notional_usd:
         raise PlanError(
-            f"Order notional {plan.notional} exceeds cap {config.max_order_notional_usd}"
+            f"Order notional {plan.notional} exceeds your configured ceiling "
+            f"{config.max_order_notional_usd}. Raise or unset HYPERGROK_MAX_ORDER_NOTIONAL_USD."
+        )
+    if plan.notional < HYPERLIQUID_MIN_ORDER_VALUE_USD:
+        raise PlanError(
+            f"Order notional {plan.notional} is below Hyperliquid's "
+            f"{HYPERLIQUID_MIN_ORDER_VALUE_USD} USD minimum order value"
         )
     digest = save_plan(plan, Path(args.out))
+    out_path = Path(args.out)
     _print(
         {
-            "plan": str(Path(args.out)),
+            "plan": str(out_path),
             "sha256": digest,
             "notional_usd": plan.notional,
-            "next": f"Review, then execute with --confirm {digest} --execute",
+            "expires_at": plan.expires_at,
+            "review_first": (
+                f"Open {out_path} and check account, network, side, size, limit price and expiry. "
+                "The hash below is what you are approving; it only matches this exact file."
+            ),
+            "next_command": (
+                f"hypergrok execute-order --plan {out_path} --confirm {digest} --execute"
+            ),
         }
     )
 
@@ -272,14 +393,16 @@ def _execute(args: argparse.Namespace) -> None:
         raise PlanError("Confirmation does not exactly match the plan hash")
     if plan.network != config.network:
         raise PlanError("Plan network differs from current configuration")
-    if plan.notional > config.max_order_notional_usd:
+    if config.max_order_notional_usd is not None and plan.notional > config.max_order_notional_usd:
         raise PlanError("Plan exceeds the current order notional cap")
     if Decimal(plan.max_slippage_bps) > config.max_slippage_bps:
         raise PlanError("Plan slippage cap exceeds the current configured cap")
     account_address = os.getenv("HYPERLIQUID_ACCOUNT_ADDRESS", "").lower()
     if account_address != plan.account.lower():
         raise PlanError("HYPERLIQUID_ACCOUNT_ADDRESS does not match the approved plan account")
-    check_builder(plan.account, lambda kind, **kw: _info(config.api_url, kind, **kw))
+    attribution = resolve_attribution(
+        plan.network, plan.account, lambda kind, **kw: _info(config.api_url, kind, **kw)
+    )
     mids = _info(config.api_url, "allMids")
     try:
         mid = Decimal(str(mids[plan.coin]))
@@ -329,6 +452,12 @@ def _execute(args: argparse.Namespace) -> None:
     if _seen_cloid(config.api_url, plan.account, plan.cloid):
         raise PlanError("This cloid already exists; refusing duplicate submission")
     attempt.transition("sending")
+    order_kwargs: dict[str, Any] = {
+        "reduce_only": plan.reduce_only,
+        "cloid": Cloid.from_str(plan.cloid),
+    }
+    if attribution.payload is not None:
+        order_kwargs["builder"] = attribution.payload
     try:
         response = exchange.order(
             plan.coin,
@@ -336,9 +465,7 @@ def _execute(args: argparse.Namespace) -> None:
             float(Decimal(plan.size)),
             float(limit_px),
             {"limit": {"tif": plan.tif}},
-            reduce_only=plan.reduce_only,
-            cloid=Cloid.from_str(plan.cloid),
-            builder={"b": GALLEON_BUILDER_ADDRESS, "f": GALLEON_BUILDER_FEE_TENTHS_BP},
+            **order_kwargs,
         )
     except Exception as exc:
         try:
@@ -358,7 +485,8 @@ def _execute(args: argparse.Namespace) -> None:
             "cloid": plan.cloid,
             "network": plan.network,
             "effect": effect,
-            "builder": {"b": GALLEON_BUILDER_ADDRESS, "f": GALLEON_BUILDER_FEE_TENTHS_BP},
+            "builder": attribution.payload,
+            "builder_attribution": attribution.reason,
             "response": response,
         }
     )
@@ -370,9 +498,138 @@ def _execute(args: argparse.Namespace) -> None:
         )
 
 
+def _quickstart(args: argparse.Namespace) -> None:
+    """Plain-English readiness check. Prints what to do next, never a secret."""
+    del args
+    lines: list[str] = []
+    todo: list[str] = []
+
+    def check(ok: bool | None, label: str, fix: str | None = None) -> None:
+        mark = {True: "[ok]", False: "[--]", None: "[??]"}[ok]
+        lines.append(f"  {mark} {label}")
+        if ok is not True and fix:
+            todo.append(fix)
+
+    try:
+        config = DeskConfig.from_env()
+    except ConfigError as exc:
+        print("HyperGrok setup\n")
+        print(f"  [--] Configuration is invalid: {exc}")
+        print("\nFix that first, then run: hypergrok quickstart")
+        return
+
+    dotenv = find_dotenv()
+    account = os.getenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
+    key_present = bool(os.getenv("HYPERLIQUID_PRIVATE_KEY"))
+
+    print("HyperGrok setup\n")
+    print(f"Network: {config.network}  ({config.api_url})")
+    if config.network == "testnet":
+        print("Testnet is the safe default. No real money is at risk here.\n")
+    else:
+        print("MAINNET. Orders here use real funds.\n")
+
+    none = "not set (no ceiling)"
+    lines.append("Optional guardrails  (unset by default -- HyperGrok imposes no risk ceiling)")
+    for label, value, var in (
+        ("max risk per trade",
+         f"{config.max_risk_pct}%" if config.max_risk_pct is not None else none,
+         "HYPERGROK_MAX_RISK_PCT"),
+        ("max order notional",
+         f"{config.max_order_notional_usd} USD" if config.max_order_notional_usd is not None else none,
+         "HYPERGROK_MAX_ORDER_NOTIONAL_USD"),
+        ("price drift tolerance", f"{config.max_slippage_bps} bps", "HYPERGROK_MAX_SLIPPAGE_BPS"),
+        ("plan lifetime", f"{config.max_plan_minutes} min", "HYPERGROK_MAX_PLAN_MINUTES"),
+    ):
+        lines.append(f"       {label:<22} {value:<22} {var}")
+    lines.append("       Real limits come from the exchange:  hypergrok limits BTC")
+    lines.append("")
+    lines.append("Configuration")
+    check(
+        dotenv is not None,
+        f"Config file: {dotenv}" if dotenv else "Config file: none found",
+        "Copy the template:  cp .env.example .env",
+    )
+
+    reachable: bool | None
+    try:
+        mids = _info(config.api_url, "allMids")
+        reachable = isinstance(mids, dict) and bool(mids)
+        markets = len(mids) if isinstance(mids, dict) else 0
+    except Exception:  # noqa: BLE001 - a readiness report should not crash
+        reachable, markets = False, 0
+    check(
+        reachable,
+        f"Hyperliquid reachable ({markets} markets)" if reachable else "Hyperliquid unreachable",
+        "Check your internet connection, then re-run.",
+    )
+
+    lines.append("")
+    lines.append("Trading account (only needed to place orders)")
+    valid_account = bool(account) and ADDRESS_RE.fullmatch(account) is not None
+    check(
+        valid_account if account else False,
+        f"HYPERLIQUID_ACCOUNT_ADDRESS = {account}" if account else "HYPERLIQUID_ACCOUNT_ADDRESS not set",
+        "Set HYPERLIQUID_ACCOUNT_ADDRESS in .env to your Hyperliquid trading account.",
+    )
+    check(
+        key_present,
+        "HYPERLIQUID_PRIVATE_KEY is set" if key_present else "HYPERLIQUID_PRIVATE_KEY not set",
+        "Create an API wallet at app.hyperliquid.xyz (Settings -> API), then put its key in .env. "
+        "Never use your seed phrase or main wallet key.",
+    )
+
+    wallet_ok: bool | None = None
+    if key_present and valid_account:
+        try:
+            from eth_account import Account
+
+            address = Account.from_key(os.environ["HYPERLIQUID_PRIVATE_KEY"]).address
+            role = _info(config.api_url, "userRole", user=address)
+            role_user = role.get("data", {}).get("user") if isinstance(role, dict) else None
+            wallet_ok = (
+                isinstance(role, dict)
+                and role.get("role") == "agent"
+                and str(role_user).lower() == account.lower()
+            )
+        except Exception:  # noqa: BLE001
+            wallet_ok = None
+        check(
+            wallet_ok,
+            "API wallet is authorised for that account"
+            if wallet_ok
+            else "API wallet does not match that account",
+            "Approve the API wallet for this trading account at app.hyperliquid.xyz.",
+        )
+
+    print("\n".join(lines))
+
+    ready = bool(reachable)
+    can_trade = ready and valid_account and key_present and wallet_ok is True
+    print()
+    if can_trade:
+        print("You can research, plan and place orders.")
+    elif ready:
+        print("You can research and plan orders. Placing them needs the account steps above.")
+    else:
+        print("Not ready yet.")
+
+    if todo:
+        print("\nNext steps:")
+        for index, item in enumerate(todo, 1):
+            print(f"  {index}. {item}")
+    else:
+        print("\nTry it:")
+        print("  hypergrok market BTC")
+        print("  hypergrok size --equity 1000 --entry 100 --stop 95 --risk-pct 0.5 --max-notional 200")
+
+
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(prog="hypergrok", description="HyperGrok trading desk")
     commands = root.add_subparsers(dest="command", required=True)
+    commands.add_parser(
+        "quickstart", help="Plain-English setup check and what to do next. Start here."
+    ).set_defaults(func=_quickstart)
     commands.add_parser("health", help="Validate config and live builder balance").set_defaults(func=_health)
 
     doctor = commands.add_parser("doctor", help="Report read and execution readiness")
@@ -414,6 +671,13 @@ def parser() -> argparse.ArgumentParser:
     builder.add_argument("user")
     builder.set_defaults(func=_builder_status)
 
+    limits = commands.add_parser(
+        "limits", help="Report the limits Hyperliquid itself enforces for a market"
+    )
+    limits.add_argument("coin")
+    limits.add_argument("--equity", help="Optional: show max position notional for this equity")
+    limits.set_defaults(func=_limits)
+
     size = commands.add_parser("size", help="Size a position from a stop")
     for name in ("equity", "entry", "stop", "risk-pct", "max-notional"):
         size.add_argument("--" + name, required=True)
@@ -440,6 +704,7 @@ def parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    load_dotenv()
     try:
         args = parser().parse_args(argv)
         args.func(args)

--- a/src/hypergrok/config.py
+++ b/src/hypergrok/config.py
@@ -10,6 +10,37 @@ from pathlib import Path
 GALLEON_BUILDER_ADDRESS = "0xC141Cbe4f4a9CAbc3cc78159a9268a4e008922CD"
 GALLEON_BUILDER_FEE_TENTHS_BP = 10
 
+# HyperGrok imposes no risk ceiling of its own. Hyperliquid already publishes
+# the real constraints per asset -- max leverage, tiered margin, lot precision,
+# minimum order value -- and `hypergrok limits <COIN>` surfaces them. Sizing
+# judgment belongs to the risk officer, not to a flat number in this file.
+#
+# The optional ceilings below are opt-in guardrails for anyone who wants the
+# CLI itself to refuse a fat-fingered number. Unset means no ceiling.
+#
+# Correctness gates -- plan hash, account match, API-wallet role, duplicate
+# cloid, tick precision, live price drift -- are not configurable and not
+# preferences.
+SANITY_MAX_RISK_PCT = Decimal("100")
+SANITY_MAX_SLIPPAGE_BPS = Decimal("1000")
+SANITY_MAX_PLAN_MINUTES = 1440
+
+# Hyperliquid's own documented minimum order value, in USD.
+HYPERLIQUID_MIN_ORDER_VALUE_USD = Decimal("10")
+
+
+def _optional_decimal(name: str) -> Decimal | None:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        value = Decimal(raw)
+    except Exception as exc:
+        raise ConfigError(f"{name} must be a number") from exc
+    if not value.is_finite():
+        raise ConfigError(f"{name} must be finite")
+    return value
+
 
 class ConfigError(ValueError):
     """Configuration is incomplete or unsafe."""
@@ -29,8 +60,14 @@ def _decimal(name: str, default: str) -> Decimal:
 class DeskConfig:
     network: str
     mainnet_enabled: bool
-    max_order_notional_usd: Decimal
+    # Optional opt-in guardrails. None means HyperGrok imposes no ceiling and
+    # the risk officer, plus Hyperliquid's own margin engine, govern the size.
+    max_order_notional_usd: Decimal | None
+    max_risk_pct: Decimal | None
+    # Not a ceiling: the live price-drift tolerance written into each plan, and
+    # the mechanism that makes "you approved this exact order" mean something.
     max_slippage_bps: Decimal
+    max_plan_minutes: int
     http_timeout_seconds: Decimal
     state_dir: Path
     builder_address: str = GALLEON_BUILDER_ADDRESS
@@ -39,11 +76,17 @@ class DeskConfig:
     @classmethod
     def from_env(cls) -> DeskConfig:
         network = os.getenv("HYPERGROK_NETWORK", "testnet").lower()
+        try:
+            plan_minutes = int(os.getenv("HYPERGROK_MAX_PLAN_MINUTES", "30"))
+        except ValueError as exc:
+            raise ConfigError("HYPERGROK_MAX_PLAN_MINUTES must be a whole number") from exc
         config = cls(
             network=network,
             mainnet_enabled=os.getenv("HYPERGROK_ENABLE_MAINNET") == "I_UNDERSTAND",
-            max_order_notional_usd=_decimal("HYPERGROK_MAX_ORDER_NOTIONAL_USD", "1000"),
+            max_order_notional_usd=_optional_decimal("HYPERGROK_MAX_ORDER_NOTIONAL_USD"),
+            max_risk_pct=_optional_decimal("HYPERGROK_MAX_RISK_PCT"),
             max_slippage_bps=_decimal("HYPERGROK_MAX_SLIPPAGE_BPS", "30"),
+            max_plan_minutes=plan_minutes,
             http_timeout_seconds=_decimal("HYPERGROK_HTTP_TIMEOUT_SECONDS", "15"),
             state_dir=Path(
                 os.getenv("HYPERGROK_STATE_DIR", str(Path.home() / ".local/state/hypergrok/executions"))
@@ -63,10 +106,22 @@ class DeskConfig:
             raise ConfigError("HYPERGROK_NETWORK must be testnet or mainnet")
         if self.network == "mainnet" and not self.mainnet_enabled:
             raise ConfigError("Mainnet is disabled; set HYPERGROK_ENABLE_MAINNET=I_UNDERSTAND")
-        if self.max_order_notional_usd <= 0:
-            raise ConfigError("Order notional cap must be positive")
-        if not Decimal("0") < self.max_slippage_bps <= Decimal("100"):
-            raise ConfigError("Slippage cap must be between 0 and 100 bps")
+        if self.max_order_notional_usd is not None and self.max_order_notional_usd <= 0:
+            raise ConfigError("HYPERGROK_MAX_ORDER_NOTIONAL_USD must be positive when set")
+        if not Decimal("0") < self.max_slippage_bps <= SANITY_MAX_SLIPPAGE_BPS:
+            raise ConfigError(
+                f"HYPERGROK_MAX_SLIPPAGE_BPS must be above 0 and at most {SANITY_MAX_SLIPPAGE_BPS} bps"
+            )
+        if self.max_risk_pct is not None and not (
+            Decimal("0") < self.max_risk_pct <= SANITY_MAX_RISK_PCT
+        ):
+            raise ConfigError(
+                f"HYPERGROK_MAX_RISK_PCT must be above 0 and at most {SANITY_MAX_RISK_PCT} when set"
+            )
+        if not 1 <= self.max_plan_minutes <= SANITY_MAX_PLAN_MINUTES:
+            raise ConfigError(
+                f"HYPERGROK_MAX_PLAN_MINUTES must be between 1 and {SANITY_MAX_PLAN_MINUTES}"
+            )
         if not Decimal("1") <= self.http_timeout_seconds <= Decimal("60"):
             raise ConfigError("HTTP timeout must be between 1 and 60 seconds")
         if not self.state_dir.is_absolute():

--- a/src/hypergrok/env.py
+++ b/src/hypergrok/env.py
@@ -1,0 +1,67 @@
+"""Load a local .env file so documented configuration actually takes effect.
+
+The repository ships a `.env.example`. Before this module existed nothing read
+`.env`, so a user who copied the example and filled it in saw every setting
+silently ignored. Real environment variables always win over file values, so
+an explicit `HYPERGROK_NETWORK=mainnet hypergrok ...` still overrides the file.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["find_dotenv", "load_dotenv", "parse_dotenv"]
+
+
+def parse_dotenv(text: str) -> dict[str, str]:
+    """Parse `KEY=value` lines, ignoring comments, blanks and `export` prefixes."""
+    values: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, separator, value = line.partition("=")
+        if not separator:
+            continue
+        key = key.strip()
+        if not key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def find_dotenv(start: Path | None = None) -> Path | None:
+    """Return the nearest `.env` at or above `start`, or None."""
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_dotenv(path: Path | None = None) -> list[str]:
+    """Apply a `.env` into `os.environ` without overriding existing variables.
+
+    Returns the names that were applied. A missing or unreadable file is not an
+    error: configuration by real environment variables must keep working.
+    """
+    target = path or find_dotenv()
+    if target is None:
+        return []
+    try:
+        text = target.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    applied = []
+    for key, value in parse_dotenv(text).items():
+        if key not in os.environ:
+            os.environ[key] = value
+            applied.append(key)
+    return applied

--- a/src/hypergrok/plans.py
+++ b/src/hypergrok/plans.py
@@ -18,7 +18,12 @@ from .config import GALLEON_BUILDER_ADDRESS, GALLEON_BUILDER_FEE_TENTHS_BP
 ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]{40}\Z")
 CLOID_RE = re.compile(r"0x[0-9a-fA-F]{32}\Z")
 COIN_RE = re.compile(r"[A-Z0-9@][A-Z0-9._:/-]{0,31}\Z")
-MAX_PLAN_LIFETIME = 30 * 60
+# Outer sanity bound on a stored plan. The user's own, tighter lifetime is
+# enforced by DeskConfig (HYPERGROK_MAX_PLAN_MINUTES); this only rejects a plan
+# file that is absurd on its face. Live price drift is rechecked at execution
+# regardless, so a longer plan is stale, not dangerous.
+MAX_PLAN_LIFETIME = 24 * 60 * 60
+MAX_PLAN_SLIPPAGE_BPS = Decimal("1000")
 MAX_PLAN_BYTES = 64 * 1024
 
 
@@ -76,8 +81,8 @@ class OrderPlan:
             raise PlanError("Size, price and slippage must be finite")
         if size <= 0 or limit_px <= 0:
             raise PlanError("Size and limit price must be positive")
-        if not Decimal("0") < slippage <= Decimal("100"):
-            raise PlanError("Slippage cap must be between 0 and 100 bps")
+        if not Decimal("0") < slippage <= MAX_PLAN_SLIPPAGE_BPS:
+            raise PlanError(f"Slippage cap must be between 0 and {MAX_PLAN_SLIPPAGE_BPS} bps")
         if self.builder_address.lower() != GALLEON_BUILDER_ADDRESS.lower():
             raise PlanError("Builder attribution changed")
         if self.builder_fee_tenths_bp != GALLEON_BUILDER_FEE_TENTHS_BP:
@@ -95,7 +100,10 @@ class OrderPlan:
             raise PlanError("Plan has expired")
         lifetime = (expires - created).total_seconds()
         if lifetime <= 0 or lifetime > MAX_PLAN_LIFETIME:
-            raise PlanError("Plan lifetime must be greater than zero and no more than 30 minutes")
+            raise PlanError(
+                f"Plan lifetime must be greater than zero and no more than "
+                f"{MAX_PLAN_LIFETIME // 3600} hours"
+            )
         if CLOID_RE.fullmatch(self.cloid) is None:
             raise PlanError("cloid must be a 128-bit hex string")
 

--- a/src/hypergrok/risk.py
+++ b/src/hypergrok/risk.py
@@ -25,14 +25,34 @@ def size_for_stop(
     stop: Decimal,
     risk_pct: Decimal,
     max_notional: Decimal,
+    max_risk_pct: Decimal | None = None,
 ) -> SizeResult:
+    """Size a position from a stop distance.
+
+    HyperGrok imposes no risk-per-trade ceiling. Hyperliquid does not define one
+    either -- its real constraints are per-asset max leverage, tiered margin and
+    the liquidation engine, which `hypergrok limits <COIN>` reports. Judging an
+    appropriate risk budget is the risk officer's job.
+
+    `max_risk_pct` is therefore an optional opt-in guardrail (HYPERGROK_MAX_RISK_PCT)
+    for anyone who wants the CLI itself to refuse a fat-fingered figure. None
+    means no ceiling; the arithmetic is identical either way.
+    """
     values = (equity, entry, stop, risk_pct, max_notional)
     if any(not value.is_finite() for value in values):
         raise RiskError("All sizing inputs must be finite")
     if equity <= 0 or entry <= 0 or stop <= 0 or max_notional <= 0:
         raise RiskError("Equity, prices and cap must be positive")
-    if not Decimal("0") < risk_pct <= Decimal("2"):
-        raise RiskError("Risk per trade must be above 0% and at most 2%")
+    if risk_pct <= 0:
+        raise RiskError("Risk per trade must be above 0%")
+    if max_risk_pct is not None:
+        if not max_risk_pct.is_finite() or max_risk_pct <= 0:
+            raise RiskError("Configured maximum risk per trade must be positive")
+        if risk_pct > max_risk_pct:
+            raise RiskError(
+                f"Risk per trade {risk_pct}% exceeds your configured ceiling of "
+                f"{max_risk_pct}%. Raise or unset HYPERGROK_MAX_RISK_PCT to allow it."
+            )
     distance = abs(entry - stop)
     if distance == 0:
         raise RiskError("Entry and stop cannot be equal")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,3 +43,48 @@ def test_http_timeout_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
         DeskConfig.from_env()
     monkeypatch.setenv("HYPERGROK_HTTP_TIMEOUT_SECONDS", "12.5")
     assert DeskConfig.from_env().http_timeout_seconds == Decimal("12.5")
+
+
+def test_risk_limits_are_user_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HYPERGROK_MAX_RISK_PCT", "7.5")
+    monkeypatch.setenv("HYPERGROK_MAX_SLIPPAGE_BPS", "250")
+    monkeypatch.setenv("HYPERGROK_MAX_PLAN_MINUTES", "120")
+    config = DeskConfig.from_env()
+    assert config.max_risk_pct == Decimal("7.5")
+    assert config.max_slippage_bps == Decimal("250")
+    assert config.max_plan_minutes == 120
+
+
+def test_no_risk_ceiling_is_imposed_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Risk appetite is the user's, and the exchange's, not HyperGrok's."""
+    for name in ("HYPERGROK_MAX_RISK_PCT", "HYPERGROK_MAX_ORDER_NOTIONAL_USD"):
+        monkeypatch.delenv(name, raising=False)
+    config = DeskConfig.from_env()
+    assert config.max_risk_pct is None
+    assert config.max_order_notional_usd is None
+
+
+def test_drift_tolerance_always_has_a_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Price drift is a correctness protection, not a risk preference."""
+    monkeypatch.delenv("HYPERGROK_MAX_SLIPPAGE_BPS", raising=False)
+    assert DeskConfig.from_env().max_slippage_bps == Decimal("30")
+
+
+def test_an_empty_value_reads_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HYPERGROK_MAX_RISK_PCT", "")
+    assert DeskConfig.from_env().max_risk_pct is None
+
+
+def test_sanity_bounds_reject_certainly_wrong_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, value, match in [
+        ("HYPERGROK_MAX_RISK_PCT", "0", "MAX_RISK_PCT"),
+        ("HYPERGROK_MAX_ORDER_NOTIONAL_USD", "-5", "NOTIONAL"),
+        ("HYPERGROK_MAX_RISK_PCT", "101", "MAX_RISK_PCT"),
+        ("HYPERGROK_MAX_SLIPPAGE_BPS", "5000", "SLIPPAGE"),
+        ("HYPERGROK_MAX_PLAN_MINUTES", "0", "PLAN_MINUTES"),
+        ("HYPERGROK_MAX_PLAN_MINUTES", "99999", "PLAN_MINUTES"),
+    ]:
+        monkeypatch.setenv(name, value)
+        with pytest.raises(ConfigError, match=match):
+            DeskConfig.from_env()
+        monkeypatch.delenv(name)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -37,16 +37,47 @@ def test_doctor_separates_read_health_from_execution_readiness(
     assert report["builder"]["user_approval_sufficient"] is None
 
 
-def test_doctor_reports_execution_ready_only_with_every_builder_gate(
+def test_doctor_never_tells_the_user_to_fund_the_builder(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The builder treasury is Galleon's concern; users must never be pointed at it."""
+    monkeypatch.setattr(cli, "_info", info_factory(value="0", abstraction="default", approval=0))
+    cli._doctor(argparse.Namespace(user=None))
+    report = json.loads(capsys.readouterr().out)
+    guidance = report["next_action"].lower()
+    assert "fund" not in guidance
+    assert cli.GALLEON_BUILDER_ADDRESS.lower() not in guidance
+
+
+def test_doctor_execution_readiness_ignores_builder_eligibility(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A user with their own setup complete is execution-ready even when the
+    builder cannot currently collect a fee."""
+    monkeypatch.setattr(cli, "_info", info_factory(value="0", abstraction="default", approval=0))
+    monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", USER)
+    monkeypatch.setenv("HYPERLIQUID_PRIVATE_KEY", "unused")
+    cli._doctor(argparse.Namespace(user=USER))
+    report = json.loads(capsys.readouterr().out)
+    assert report["execution_ready"]
+    assert not report["builder"]["eligible_by_balance"]
+    assert report["builder"]["attribution_active"] is False
+
+
+def test_doctor_reports_attribution_when_every_builder_gate_passes(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(cli, "_info", info_factory(value="100", abstraction="disabled", approval=10))
+    monkeypatch.setenv("HYPERGROK_NETWORK", "mainnet")
+    monkeypatch.setenv("HYPERGROK_ENABLE_MAINNET", "I_UNDERSTAND")
+    monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", USER)
+    monkeypatch.setenv("HYPERLIQUID_PRIVATE_KEY", "unused")
     cli._doctor(argparse.Namespace(user=USER))
     report = json.loads(capsys.readouterr().out)
     assert report["status"] == "execution-ready"
-    assert report["execution_ready"]
     assert report["builder"]["standard_mode"]
     assert report["builder"]["user_approval_sufficient"]
+    assert report["builder"]["attribution_active"]
 
 
 def test_doctor_rejects_malformed_user_before_network(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from hypergrok.env import find_dotenv, load_dotenv, parse_dotenv
+
+
+def test_parses_comments_blanks_quotes_and_export() -> None:
+    parsed = parse_dotenv(
+        "\n".join(
+            [
+                "# a comment",
+                "",
+                "HYPERGROK_NETWORK=testnet",
+                "export HYPERGROK_MAX_SLIPPAGE_BPS=30",
+                'QUOTED="value with spaces"',
+                "SINGLE='single'",
+                "  SPACED  =  padded  ",
+                "no_equals_sign",
+            ]
+        )
+    )
+    assert parsed["HYPERGROK_NETWORK"] == "testnet"
+    assert parsed["HYPERGROK_MAX_SLIPPAGE_BPS"] == "30"
+    assert parsed["QUOTED"] == "value with spaces"
+    assert parsed["SINGLE"] == "single"
+    assert parsed["SPACED"] == "padded"
+    assert "no_equals_sign" not in parsed
+
+
+def test_load_applies_values(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env = tmp_path / ".env"
+    env.write_text("HYPERGROK_TEST_ONLY=from_file\n")
+    monkeypatch.delenv("HYPERGROK_TEST_ONLY", raising=False)
+    assert load_dotenv(env) == ["HYPERGROK_TEST_ONLY"]
+    assert os.environ["HYPERGROK_TEST_ONLY"] == "from_file"
+
+
+def test_real_environment_wins_over_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env = tmp_path / ".env"
+    env.write_text("HYPERGROK_TEST_ONLY=from_file\n")
+    monkeypatch.setenv("HYPERGROK_TEST_ONLY", "from_shell")
+    assert load_dotenv(env) == []
+    assert os.environ["HYPERGROK_TEST_ONLY"] == "from_shell"
+
+
+def test_missing_file_is_not_an_error(tmp_path: Path) -> None:
+    assert load_dotenv(tmp_path / "absent.env") == []
+
+
+def test_find_walks_upwards(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("A=1\n")
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    assert find_dotenv(nested) == tmp_path / ".env"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 
 import pytest
 
+from hypergrok import builder as builder_module
 from hypergrok import cli
 from hypergrok.builder import BuilderError
 from hypergrok.config import GALLEON_BUILDER_ADDRESS
@@ -109,17 +110,64 @@ def test_exact_confirmation_is_required_before_sdk_import(tmp_path: Path, monkey
     assert FakeExchange.sends == []
 
 
-def test_builder_failure_means_zero_sends(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_builder_failure_still_sends_but_without_attribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Galleon's revenue plumbing must never block someone else's trade."""
+    FakeExchange.sends.clear()
+    path = tmp_path / "p.json"
+    digest = make_plan(path, network="mainnet")
+    monkeypatch.setenv("HYPERGROK_NETWORK", "mainnet")
+    monkeypatch.setenv("HYPERGROK_ENABLE_MAINNET", "I_UNDERSTAND")
+    monkeypatch.setenv("HYPERLIQUID_PRIVATE_KEY", "unused")
+    monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", ACCOUNT)
+    install_sdk(monkeypatch)
+    monkeypatch.setattr(cli, "_info", lambda base, kind, **kw: live_info(kind, **kw))
+    monkeypatch.setattr(
+        builder_module, "inspect_builder", lambda *a, **k: (_ for _ in ()).throw(BuilderError("no"))
+    )
+    cli._execute(args(path, digest))
+    assert len(FakeExchange.sends) == 1
+    assert "builder" not in FakeExchange.sends[0][1]
+
+
+def test_ineligible_builder_does_not_block_the_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    FakeExchange.sends.clear()
+    path = tmp_path / "p.json"
+    digest = make_plan(path, network="mainnet")
+    monkeypatch.setenv("HYPERGROK_NETWORK", "mainnet")
+    monkeypatch.setenv("HYPERGROK_ENABLE_MAINNET", "I_UNDERSTAND")
+    monkeypatch.setenv("HYPERLIQUID_PRIVATE_KEY", "unused")
+    monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", ACCOUNT)
+    install_sdk(monkeypatch)
+
+    def broke_builder(base, kind, **kwargs):
+        del base
+        if kind == "clearinghouseState":
+            return {"marginSummary": {"accountValue": "0"}}
+        return live_info(kind, **kwargs)
+
+    monkeypatch.setattr(cli, "_info", broke_builder)
+    cli._execute(args(path, digest))
+    assert len(FakeExchange.sends) == 1
+    assert "builder" not in FakeExchange.sends[0][1]
+
+
+def test_testnet_never_attaches_builder_attribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     FakeExchange.sends.clear()
     path = tmp_path / "p.json"
     digest = make_plan(path)
     monkeypatch.setenv("HYPERLIQUID_PRIVATE_KEY", "unused")
     monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", ACCOUNT)
     install_sdk(monkeypatch)
-    monkeypatch.setattr(cli, "check_builder", lambda *a, **k: (_ for _ in ()).throw(BuilderError("no")))
-    with pytest.raises(BuilderError):
-        cli._execute(args(path, digest))
-    assert FakeExchange.sends == []
+    monkeypatch.setattr(cli, "_info", lambda base, kind, **kw: live_info(kind, **kw))
+    cli._execute(args(path, digest))
+    assert len(FakeExchange.sends) == 1
+    assert "builder" not in FakeExchange.sends[0][1]
 
 
 def test_declared_account_must_match_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -134,10 +182,13 @@ def test_declared_account_must_match_plan(tmp_path: Path, monkeypatch: pytest.Mo
 
 
 def test_only_send_includes_builder_and_cloid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On mainnet, with every builder gate satisfied, the fee is attributed."""
     FakeExchange.sends.clear()
     FakeExchange.timeouts.clear()
     path = tmp_path / "p.json"
-    digest = make_plan(path)
+    digest = make_plan(path, network="mainnet")
+    monkeypatch.setenv("HYPERGROK_NETWORK", "mainnet")
+    monkeypatch.setenv("HYPERGROK_ENABLE_MAINNET", "I_UNDERSTAND")
     monkeypatch.setenv("HYPERLIQUID_PRIVATE_KEY", "unused")
     monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", ACCOUNT)
     install_sdk(monkeypatch)

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,95 @@
+import argparse
+import json
+
+import pytest
+
+from hypergrok import cli
+
+META = {
+    "universe": [
+        {"name": "BTC", "szDecimals": 5, "maxLeverage": 40, "marginTableId": 51},
+        {"name": "HYPE", "szDecimals": 2, "maxLeverage": 10, "marginTableId": 52},
+    ],
+    "marginTables": [
+        [51, {"description": "tiered", "marginTiers": [
+            {"lowerBound": "0.0", "maxLeverage": 40},
+            {"lowerBound": "10000.0", "maxLeverage": 25},
+        ]}],
+        [52, {"description": "", "marginTiers": [{"lowerBound": "0.0", "maxLeverage": 10}]}],
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def meta(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_info", lambda base, kind, **kw: META)
+
+
+def report(capsys, **kwargs):
+    cli._limits(argparse.Namespace(coin=kwargs.pop("coin", "BTC"),
+                                   equity=kwargs.pop("equity", None)))
+    return json.loads(capsys.readouterr().out)
+
+
+def test_reports_the_exchange_limits(capsys: pytest.CaptureFixture[str]) -> None:
+    data = report(capsys)
+    limits = data["exchange_limits"]
+    assert limits["max_leverage"] == 40
+    assert limits["size_decimals"] == 5
+    assert limits["min_order_value_usd"] == "10"
+    assert data["coin"] == "BTC"
+
+
+def test_margin_tiers_are_resolved_for_the_right_table(
+    capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Headline leverage is the top tier only; the tiers are the real constraint."""
+    tiers = report(capsys)["exchange_limits"]["margin_tiers"]
+    assert tiers == [
+        {"lower_bound_usd": "0.0", "max_leverage": 40},
+        {"lower_bound_usd": "10000.0", "max_leverage": 25},
+    ]
+    hype = report(capsys, coin="HYPE")["exchange_limits"]["margin_tiers"]
+    assert hype == [{"lower_bound_usd": "0.0", "max_leverage": 10}]
+
+
+def test_reports_that_hypergrok_imposes_no_ceiling_by_default(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in ("HYPERGROK_MAX_RISK_PCT", "HYPERGROK_MAX_ORDER_NOTIONAL_USD"):
+        monkeypatch.delenv(name, raising=False)
+    ceilings = report(capsys)["hypergrok_ceilings"]
+    assert ceilings["max_risk_pct"] is None
+    assert ceilings["max_order_notional_usd"] is None
+
+
+def test_reports_an_opt_in_ceiling_when_one_is_set(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HYPERGROK_MAX_RISK_PCT", "3")
+    assert report(capsys)["hypergrok_ceilings"]["max_risk_pct"] == "3"
+
+
+def test_equity_yields_max_position_notional(capsys: pytest.CaptureFixture[str]) -> None:
+    scoped = report(capsys, equity="10000")["for_your_equity"]
+    assert scoped["max_position_notional_usd"] == "400000"
+    assert scoped["equity_usd"] == "10000"
+
+
+def test_equity_is_optional(capsys: pytest.CaptureFixture[str]) -> None:
+    assert "for_your_equity" not in report(capsys)
+
+
+@pytest.mark.parametrize("equity", ["0", "-5", "abc"])
+def test_bad_equity_is_refused(equity: str) -> None:
+    with pytest.raises(cli.RiskError):
+        cli._limits(argparse.Namespace(coin="BTC", equity=equity))
+
+
+def test_unknown_market_is_refused() -> None:
+    with pytest.raises(cli.ApiError, match="Unknown perp market"):
+        cli._limits(argparse.Namespace(coin="NOTACOIN", equity=None))
+
+
+def test_coin_lookup_is_case_insensitive(capsys: pytest.CaptureFixture[str]) -> None:
+    assert report(capsys, coin="btc")["coin"] == "BTC"

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -54,7 +54,7 @@ def test_expired_and_changed_builder_are_rejected() -> None:
         ("cloid", "0x" + "z" * 32, "128-bit"),
         ("size", "NaN", "finite"),
         ("limit_px", "Infinity", "finite"),
-        ("max_slippage_bps", "101", "Slippage"),
+        ("max_slippage_bps", "1001", "Slippage"),
         ("coin", "BTC BUY", "market identifier"),
     ],
 )
@@ -63,14 +63,25 @@ def test_malformed_plan_fields_are_rejected(field: str, value: str, message: str
         replace(plan(), **{field: value}).validate()
 
 
-def test_plan_lifetime_is_bounded() -> None:
+def test_plan_lifetime_is_bounded_by_an_outer_sanity_limit() -> None:
+    """plans.py holds only the outer bound. The user's own, tighter lifetime is
+    policy and lives in DeskConfig -- see test_config.py."""
     now = datetime.now(UTC)
-    with pytest.raises(PlanError, match="30 minutes"):
+    with pytest.raises(PlanError, match="hours"):
         replace(
             plan(),
             created_at=now.isoformat(),
-            expires_at=(now + timedelta(minutes=31)).isoformat(),
+            expires_at=(now + timedelta(hours=25)).isoformat(),
         ).validate(now=now)
+
+
+def test_a_plan_inside_the_sanity_bound_is_accepted() -> None:
+    now = datetime.now(UTC)
+    replace(
+        plan(),
+        created_at=now.isoformat(),
+        expires_at=(now + timedelta(minutes=31)).isoformat(),
+    ).validate(now=now)
 
 
 def test_save_refuses_to_overwrite_existing_plan(tmp_path: Path) -> None:

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -18,10 +18,44 @@ def test_size_is_bounded_by_notional_cap() -> None:
     assert result.risk_usd == Decimal("10.00000000")
 
 
-@pytest.mark.parametrize("risk", ["0", "2.01", "NaN"])
+@pytest.mark.parametrize("risk", ["0", "-1", "NaN"])
 def test_invalid_risk_fails_closed(risk: str) -> None:
     with pytest.raises(RiskError):
         size_for_stop(
             equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
             risk_pct=Decimal(risk), max_notional=Decimal("1000")
         )
+
+
+def test_no_ceiling_is_imposed_by_default() -> None:
+    """HyperGrok has no opinion on risk appetite; the risk officer does."""
+    result = size_for_stop(equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
+                           risk_pct=Decimal("25"), max_notional=Decimal("1000000"))
+    assert result.risk_usd == Decimal("2500.00000000")
+
+
+def test_an_opt_in_ceiling_is_honoured_when_set() -> None:
+    with pytest.raises(RiskError, match="exceeds your configured ceiling"):
+        size_for_stop(equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
+                      risk_pct=Decimal("5"), max_notional=Decimal("100000"),
+                      max_risk_pct=Decimal("2"))
+    allowed = size_for_stop(equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
+                            risk_pct=Decimal("5"), max_notional=Decimal("100000"),
+                            max_risk_pct=Decimal("10"))
+    assert allowed.risk_usd == Decimal("500.00000000")
+
+
+def test_setting_a_ceiling_never_changes_the_arithmetic() -> None:
+    tight = size_for_stop(equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
+                          risk_pct=Decimal("1"), max_notional=Decimal("100000"))
+    loose = size_for_stop(equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
+                          risk_pct=Decimal("1"), max_notional=Decimal("100000"),
+                          max_risk_pct=Decimal("50"))
+    assert tight == loose
+
+
+def test_a_nonsensical_ceiling_is_still_refused() -> None:
+    with pytest.raises(RiskError, match="maximum risk"):
+        size_for_stop(equity=Decimal("10000"), entry=Decimal("100"), stop=Decimal("95"),
+                      risk_pct=Decimal("1"), max_notional=Decimal("1000"),
+                      max_risk_pct=Decimal("0"))


### PR DESCRIPTION
Supersedes #11, which GitHub permanently closed when `main`'s history was
rewritten. Same branch, same content, re-parented onto the new root commit.

A single commit covering setup, risk limits, execution and verification.

## Setup

- `hypergrok quickstart`: plain-English readiness check that prints the exact
  next step and never prints a key
- `.env` is now loaded from the working directory or any parent. Previously
  `.env.example` documented settings that nothing read, so a user's config was
  silently ignored. Real environment variables still win
- `plan-order` emits a copy-pasteable `next_command` including `--plan`
- `doctor` reports the user's own setup instead of operational tasks that are
  not theirs to perform

## Risk limits come from the exchange

- `hypergrok limits <COIN>` reports what Hyperliquid actually enforces:
  per-asset max leverage, tiered margin, size decimals, minimum order value
- HyperGrok's own risk-per-trade and notional ceilings are removed. Both are
  opt-in and unset by default; sizing judgment belongs to the risk officer
- Hyperliquid's 10 USD minimum order value is enforced at plan time

## Execution

- Fee attribution no longer blocks a user's order. Previously every user was
  hard-blocked from executing whenever the treasury was below its threshold,
  for a reason they could not act on. An order that cannot carry attribution is
  now sent without it, and attribution applies on mainnet only
- Every user-safety gate is unchanged and still fails closed

## Verification

- 92 unit tests, 76% coverage
- `scripts/verify_cli.py` (54 checks), `verify_repo.py` (43), `verify_skills.py`
  (68) exercise the real CLI, the packaging and every skill procedure against
  live endpoints without signing, submitting or handling a key

## Docs

- README rewritten as product documentation with a ten-minute first run
- CHANGELOG, ARCHITECTURE and TESTING brought back in line with the code

## Open decisions

- `test_repository.py:86` forbids any markdown mentioning the fee, so it is
  documented nowhere in prose. Worth a deliberate call before going public
- The treasury still reports `default` account abstraction, so attribution is
  inactive on both networks