### PR TITLE
Add marketplace manifests for Claude, Grok, and Cursor listings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "hypergrok",
+  "owner": {
+    "name": "Galleon Labs",
+    "email": "gm@galleonlabs.io"
+  },
+  "metadata": {
+    "description": "Hyperliquid trading desk roles and skills for Claude Code",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "hypergrok",
+      "source": "./",
+      "description": "Turn your agent into a 7-role Hyperliquid trading desk: research, risk, execution and review.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Galleon Labs"
+      },
+      "homepage": "https://github.com/galleonlabs/hypergrok-trading-desk",
+      "repository": "https://github.com/galleonlabs/hypergrok-trading-desk",
+      "license": "MIT",
+      "keywords": ["hyperliquid", "trading-desk", "agents", "grok-bot"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "hypergrok",
+  "description": "Turn your agent into a Hyperliquid trading desk: seven specialist roles with full system prompts and sixteen skills for research, risk, execution and review.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Galleon Labs",
+    "url": "https://galleonlabs.io"
+  },
+  "homepage": "https://github.com/galleonlabs/hypergrok-trading-desk",
+  "repository": "https://github.com/galleonlabs/hypergrok-trading-desk",
+  "license": "MIT",
+  "keywords": ["hyperliquid", "trading-desk", "agents", "grok-bot", "agent-skills"]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -8,6 +8,7 @@
   "homepage": "https://github.com/galleonlabs/hypergrok-trading-desk",
   "repository": "https://github.com/galleonlabs/hypergrok-trading-desk",
   "license": "MIT",
+  "logo": "assets/mascot-320.jpg",
   "keywords": ["grok-bot", "hyperliquid", "trading-desk", "agents"],
   "skills": "./skills/",
   "agents": "./agents/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "hypergrok",
+  "description": "Hyperliquid trading desk for Grok Build",
+  "owner": {
+    "name": "Galleon Labs"
+  },
+  "plugins": [
+    {
+      "name": "hypergrok",
+      "description": "Turn Grok Build into a 7-role Hyperliquid trading desk: research, risk, execution and review.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./"
+      },
+      "homepage": "https://github.com/galleonlabs/hypergrok-trading-desk",
+      "keywords": ["hypergrok", "hyperliquid", "trading desk", "grok bot"],
+      "version": "1.0.0",
+      "author": {
+        "name": "Galleon Labs"
+      },
+      "tags": ["trading", "hyperliquid", "agents"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so Claude Code can load and validate the repo as a marketplace (`claude plugin validate` passes).
- Adds a self-hosted `.grok-plugin/marketplace.json` so Grok Build can `marketplace add galleonlabs/hypergrok-trading-desk`.
- Points the Cursor plugin logo at `assets/mascot-320.jpg`.

## Test plan
- [x] `claude plugin validate . --strict`
- [ ] `/plugin marketplace add galleonlabs/hypergrok-trading-desk` after merge