### PR TITLE
ci: validate plugin distribution manifests in the release check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,8 @@ HyperGrok is instructions and resources for a user's Grok Bot, not software the 
 bash scripts/check.sh
 ```
 
-The check verifies frontmatter, directory/name agreement, description length, internal links and the one-writer rule. CI runs the same script.
+The check runs three passes and CI runs the same script:
+
++ Instruction files: frontmatter, directory/name agreement, description length, internal links and the one-writer rule.
++ `scripts/check_manifests.py` - the plugin distribution contract. Every manifest (`plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.grok-plugin/plugin.json`, `.grok-plugin/marketplace.json`) must be valid JSON, name the same plugin at the same version as `plugin.json`, point every declared source, logo, skills, agents and rules path at something that exists inside this repository, and claim the counts the repository actually ships. Adding or removing a skill or role means updating the manifests that state the count in prose.
++ `scripts/test_check_manifests.py` - negative fixtures that prove the manifest check fails on a version mismatch, a missing component path, invalid JSON and inventory drift.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -112,3 +112,7 @@ if errors:
     print("\n".join(errors)); print(f"{len(errors)} problem(s)"); sys.exit(1)
 print(f"ok: {len(skills)} skills, {len(agents)} agents, {len(md_files)} markdown files checked")
 PY
+
+# The plugin distribution contract: manifests, shared identity, component paths.
+python3 scripts/check_manifests.py .
+python3 scripts/test_check_manifests.py

--- a/scripts/check_manifests.py
+++ b/scripts/check_manifests.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validates the plugin distribution manifests. Stdlib Python only; no network.
+
+Every marketplace and plugin manifest in this repository describes the same
+distributable: one plugin named `hypergrok` at one version, pointing at the
+skills, agents and rules checked in here. This script fails the build when a
+manifest stops matching what the repository actually ships.
+
+Usage: python3 scripts/check_manifests.py [repo-root]
+"""
+import json
+import os
+import re
+import sys
+
+CANONICAL_NAME = "hypergrok"
+REPOSITORY = "https://github.com/galleonlabs/hypergrok-trading-desk"
+
+MANIFESTS = [
+    "plugin.json",
+    ".claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+    ".cursor-plugin/plugin.json",
+    ".grok-plugin/plugin.json",
+    ".grok-plugin/marketplace.json",
+]
+
+# Manifest keys whose value is a path into this repository.
+PATH_KEYS = ("source", "logo", "skills", "agents", "rules")
+
+NUMBER_WORDS = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+    "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
+    "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
+    "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+    "twenty": 20,
+}
+COUNT_RE = re.compile(r"\b([A-Za-z]+|\d+)[ -](?:specialist |shared )?(roles?|skills?)\b")
+
+
+def load(root, rel, errors):
+    path = os.path.join(root, rel)
+    if not os.path.exists(path):
+        errors.append(f"{rel}: manifest is missing")
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        errors.append(f"{rel}: invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}")
+    except UnicodeDecodeError as exc:
+        errors.append(f"{rel}: not valid UTF-8: {exc}")
+    return None
+
+
+def entries(data):
+    """The manifest object itself plus any nested marketplace plugin entries."""
+    if not isinstance(data, dict):
+        return []
+    found = [("", data)]
+    for i, plugin in enumerate(data.get("plugins") or []):
+        if isinstance(plugin, dict):
+            found.append((f"plugins[{i}].", plugin))
+    return found
+
+
+def check_paths(root, rel, prefix, entry, errors):
+    for key in PATH_KEYS:
+        if key not in entry:
+            continue
+        value = entry[key]
+        if isinstance(value, dict):
+            if value.get("type") not in (None, "local"):
+                continue  # a remote source is not this repository's tree
+            value = value.get("path")
+        if not isinstance(value, str) or not value:
+            errors.append(f"{rel}: {prefix}{key} is not a path")
+            continue
+        if value.startswith(("http://", "https://")):
+            errors.append(f"{rel}: {prefix}{key} must be a repository path, not a URL")
+            continue
+        resolved = os.path.normpath(os.path.join(root, value))
+        inside = os.path.normpath(root)
+        if os.path.relpath(resolved, inside).startswith(".."):
+            errors.append(f"{rel}: {prefix}{key} '{value}' resolves outside the repository")
+            continue
+        if not os.path.exists(resolved):
+            errors.append(f"{rel}: {prefix}{key} '{value}' does not exist")
+
+
+def declared_counts(value, found):
+    """Collect counts a manifest claims in prose, e.g. 'sixteen skills'."""
+    if isinstance(value, dict):
+        for item in value.values():
+            declared_counts(item, found)
+    elif isinstance(value, list):
+        for item in value:
+            declared_counts(item, found)
+    elif isinstance(value, str):
+        for token, noun in COUNT_RE.findall(value.lower()):
+            count = int(token) if token.isdigit() else NUMBER_WORDS.get(token)
+            if count is not None:
+                found.append((count, "skills" if noun.startswith("skill") else "roles"))
+
+
+def main(root):
+    errors = []
+    skills = sorted(
+        d for d in os.listdir(os.path.join(root, "skills"))
+        if os.path.exists(os.path.join(root, "skills", d, "SKILL.md"))
+    )
+    agents = sorted(f for f in os.listdir(os.path.join(root, "agents")) if f.endswith(".md"))
+    inventory = {"skills": len(skills), "roles": len(agents)}
+    if not skills:
+        errors.append("skills/: no skill directories with a SKILL.md")
+    if not agents:
+        errors.append("agents/: no agent files")
+
+    root_manifest = load(root, MANIFESTS[0], errors)
+    version = (root_manifest or {}).get("version")
+    if not isinstance(version, str) or not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        errors.append(f"{MANIFESTS[0]}: version '{version}' is not a semantic version")
+        version = None
+
+    for rel in MANIFESTS:
+        data = root_manifest if rel == MANIFESTS[0] else load(root, rel, errors)
+        if data is None:
+            continue
+        for prefix, entry in entries(data):
+            name = entry.get("name")
+            if name != CANONICAL_NAME:
+                errors.append(f"{rel}: {prefix}name '{name}' should be '{CANONICAL_NAME}'")
+            declared = entry.get("version", (entry.get("metadata") or {}).get("version"))
+            if declared is not None and version is not None and declared != version:
+                errors.append(
+                    f"{rel}: {prefix}version '{declared}' does not match "
+                    f"{MANIFESTS[0]} version '{version}'"
+                )
+            for key in ("repository", "homepage"):
+                if key in entry and entry[key] != REPOSITORY:
+                    errors.append(f"{rel}: {prefix}{key} '{entry[key]}' should be '{REPOSITORY}'")
+            check_paths(root, rel, prefix, entry, errors)
+
+        counts = []
+        declared_counts(data, counts)
+        for count, noun in counts:
+            if count != inventory[noun]:
+                errors.append(
+                    f"{rel}: claims {count} {noun} but the repository ships {inventory[noun]}"
+                )
+
+    if errors:
+        print("\n".join(errors))
+        print(f"{len(errors)} problem(s)")
+        return 1
+    print(f"ok: {len(MANIFESTS)} manifests, {len(skills)} skills, {len(agents)} agents")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "."))

--- a/scripts/test_check_manifests.py
+++ b/scripts/test_check_manifests.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Negative fixtures for scripts/check_manifests.py. Stdlib Python only; no network.
+
+Each fixture copies the repository into a temporary directory, breaks the
+distribution contract in exactly one way, and asserts the validator fails with
+an error naming that file. A guard nobody has watched fail is not a guard.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VALIDATOR = os.path.join(ROOT, "scripts", "check_manifests.py")
+
+
+def run(root):
+    proc = subprocess.run(
+        [sys.executable, VALIDATOR, root], capture_output=True, text=True, check=False
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def edit(root, rel, mutate):
+    path = os.path.join(root, rel)
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    mutate(data)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def version_mismatch(root):
+    edit(root, ".grok-plugin/plugin.json", lambda d: d.update(version="9.9.9"))
+    return ".grok-plugin/plugin.json", "version"
+
+
+def nested_version_mismatch(root):
+    edit(root, ".claude-plugin/marketplace.json",
+         lambda d: d["plugins"][0].update(version="0.1.0"))
+    return ".claude-plugin/marketplace.json", "plugins[0].version"
+
+
+def missing_component_path(root):
+    os.remove(os.path.join(root, "assets", "mascot-320.jpg"))
+    return ".cursor-plugin/plugin.json", "logo"
+
+
+def missing_component_directory(root):
+    shutil.rmtree(os.path.join(root, "rules"))
+    return ".cursor-plugin/plugin.json", "rules"
+
+
+def path_escapes_repository(root):
+    edit(root, ".cursor-plugin/plugin.json", lambda d: d.update(skills="../skills/"))
+    return ".cursor-plugin/plugin.json", "outside the repository"
+
+
+def invalid_json(root):
+    path = os.path.join(root, ".claude-plugin", "marketplace.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write('{"name": "hypergrok",\n')
+    return ".claude-plugin/marketplace.json", "invalid JSON"
+
+
+def inventory_drift(root):
+    added = os.path.join(root, "skills", "desk-new-skill")
+    os.makedirs(added)
+    with open(os.path.join(added, "SKILL.md"), "w", encoding="utf-8") as fh:
+        fh.write("---\nname: desk-new-skill\n---\n")
+    return "plugin.json", "ships 17"
+
+
+def wrong_name(root):
+    edit(root, ".grok-plugin/marketplace.json", lambda d: d["plugins"][0].update(name="hyper-grok"))
+    return ".grok-plugin/marketplace.json", "plugins[0].name"
+
+
+FIXTURES = [
+    version_mismatch,
+    nested_version_mismatch,
+    missing_component_path,
+    missing_component_directory,
+    path_escapes_repository,
+    invalid_json,
+    inventory_drift,
+    wrong_name,
+]
+
+
+def main():
+    failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        baseline = os.path.join(tmp, "baseline")
+        shutil.copytree(ROOT, baseline, ignore=shutil.ignore_patterns(".git", "__pycache__"))
+        code, output = run(baseline)
+        if code != 0:
+            failures.append(f"baseline copy should pass but failed:\n{output}")
+
+        for fixture in FIXTURES:
+            case = os.path.join(tmp, fixture.__name__)
+            shutil.copytree(baseline, case)
+            rel, needle = fixture(case)
+            code, output = run(case)
+            if code == 0:
+                failures.append(f"{fixture.__name__}: validator passed but should have failed")
+            elif rel not in output or needle not in output:
+                failures.append(
+                    f"{fixture.__name__}: expected an error naming '{rel}' and '{needle}', got:\n{output}"
+                )
+
+    if failures:
+        print("\n".join(failures))
+        print(f"{len(failures)} problem(s)")
+        return 1
+    print(f"ok: {len(FIXTURES)} manifest fixtures fail the check as expected")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #16.

## Problem

`scripts/check.sh` validated Markdown frontmatter, links and the one-writer rule, and nothing else. The six manifests that define what this repository distributes were never parsed by CI, so a malformed manifest, a version that drifted between the Claude, Cursor and Grok surfaces, or a component path that stopped resolving could merge with a green check.

## Change

+ `scripts/check_manifests.py` (stdlib only, no network) validates the distribution contract across `plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, `.grok-plugin/plugin.json` and `.grok-plugin/marketplace.json`:
  - each parses as JSON, with a file, line and column on failure;
  - every top-level and nested marketplace entry names `hypergrok` at the version declared in `plugin.json`, with the canonical `repository`/`homepage` where those fields exist;
  - every declared `source`, `logo`, `skills`, `agents` and `rules` path resolves to something that exists inside the repository, and a path that escapes the tree is an error;
  - the counts the manifests state in prose (`seven specialist roles`, `sixteen skills`, `7-role`) are compared against the checked-in inventory, so a component cannot be added or removed while a manifest keeps advertising the old desk.
+ `scripts/test_check_manifests.py` proves the guard fires. Eight fixtures copy the repository, break exactly one thing, and assert the validator fails with an error naming that file: version mismatch, nested marketplace version mismatch, deleted logo, deleted `rules/`, path escaping the repository, invalid JSON, an extra skill, and a wrong plugin name.
+ `scripts/check.sh` runs both after the existing pass, so the required `check` job covers them with no workflow change.
+ `CONTRIBUTING.md` describes the three passes and the rule that changing the inventory means updating the manifests that state a count.

## Verification

```
$ bash scripts/check.sh
ok: 16 skills, 7 agents, 32 markdown files checked
ok: 6 manifests, 16 skills, 7 agents
ok: 8 manifest fixtures fail the check as expected

$ claude plugin validate . --strict
Validation passed
```

No behaviour change for users of the desk: this is repository verification only.