### PR TITLE
fix: stop pointing the websocket watch at the rejected webData2 subscription

### DIFF
--- a/skills/hyperliquid-websocket/SKILL.md
+++ b/skills/hyperliquid-websocket/SKILL.md
@@ -71,7 +71,7 @@ while True:
     time.sleep(60)
 ```
 
-The SDK's manager pings for you but does **not** reconnect on drop; run it under a supervisor (see below) and treat a silent log as a dead watch. It also only routes these subscription types to your callback: `allMids`, `l2Book`, `trades`, `candle`, `bbo`, `userEvents`, `userFills`, `orderUpdates`, `userFundings`, `userNonFundingLedgerUpdates`, `webData2`, `activeAssetCtx`, `activeAssetData`. Others in the table (`clearinghouseState`, `openOrders`, `twapStates`, `userTwapSliceFills`, `webData3`, `notification`) are acknowledged by the server but silently dropped by the Python SDK; use the raw socket or the TypeScript client for those.
+The SDK's manager pings for you but does **not** reconnect on drop; run it under a supervisor (see below) and treat a silent log as a dead watch. It also only routes these subscription types to your callback: `allMids`, `l2Book`, `trades`, `candle`, `bbo`, `userEvents`, `userFills`, `orderUpdates`, `userFundings`, `userNonFundingLedgerUpdates`, `activeAssetCtx`, `activeAssetData`. Others in the table (`clearinghouseState`, `openOrders`, `twapStates`, `userTwapSliceFills`, `webData3`, `notification`) are acknowledged by the server but silently dropped by the Python SDK; use the raw socket or the TypeScript client for those. The SDK routes one more type, `webData2`, but do not subscribe to it: the live server rejects that frame on mainnet and testnet with `{"channel":"error"}` and the watch never starts. `webData2` survives only as an `/info` request; the frontend snapshot stream is `webData3`, which SDK 0.24.0 cannot route at all.
 
 Run in the background from the desk computer:
 


### PR DESCRIPTION
`skills/hyperliquid-websocket` told the desk that the Python SDK routes `webData2` to a callback, listing it alongside `allMids` and `userFills` on the working side of the split against the types the server acknowledges but the SDK drops. The live server does not accept that subscription at all, so a user who followed the note got an `error` frame and a watch that silently never started.

## Evidence, live API, 2026-08-28

+ `{"method":"subscribe","subscription":{"type":"webData2","user":"0x..."}}` on `wss://api.hyperliquid.xyz/ws` **and** `wss://api.hyperliquid-testnet.xyz/ws` answers `{"channel":"error","data":"Error parsing JSON into valid websocket request: ..."}`.
+ All 23 other subscription types named in this skill and in `hyperliquid-api-reference` answer `subscriptionResponse`, `webData3` included.
+ `POST /info {"type":"webData2","user":"0x..."}` still returns 200, so the type is alive as a request and dead only as a subscription.
+ `hyperliquid-python-sdk` 0.24.0 (`websocket_manager.py:32`) keys on `webData2` and has no `webData3` branch; `@nktkas/hyperliquid` 0.33.3 ships `webData3` under its subscription methods and keeps `webData2` under its info methods. Both are the versions pinned in `docs/PROVENANCE.md`.

## Change

One sentence in one file. `webData2` leaves the routed list, and the note now states that it is an `/info` request, that `webData3` is the frontend snapshot stream, and that SDK 0.24.0 cannot route `webData3` either — so that stream needs the raw socket or the TypeScript client. The subscription table already named `webData3` correctly and is unchanged.

## Checks

`bash scripts/check.sh` passes locally: 16 skills, 7 agents, 32 markdown files; 6 manifests; 8 negative manifest fixtures still fail as expected. The check is offline by design, so it cannot catch live-API drift like this one.