### PR TITLE
fix: normalise predictedFundings by each venue's own funding interval

### DIFF
--- a/skills/hyperliquid-api-reference/SKILL.md
+++ b/skills/hyperliquid-api-reference/SKILL.md
@@ -38,7 +38,7 @@ Verified against the official docs on 2026-08-16. When in doubt, fetch the page:
 | `recentTrades` | `coin` | `[{coin, side, px, sz, time, hash, tid}]` |
 | `candleSnapshot` | `req:{coin, interval, startTime, endTime}` | `[{t,T,s,i,o,c,h,l,v,n}]`, most recent 5000 only |
 | `fundingHistory` | `coin, startTime, endTime?` | `[{coin, fundingRate (hourly), premium, time}]` |
-| `predictedFundings` | | `[[coin, [[venue, {fundingRate, nextFundingTime}]]]]` (HlPerp hourly; CEX venues 8h) |
+| `predictedFundings` | | `[[coin, [[venue, {fundingRate, nextFundingTime, fundingIntervalHours?}]]]]`; venue is `HlPerp`, `BinPerp` or `BybitPerp`, payload `null` when unlisted there. Normalise by `fundingIntervalHours` (HlPerp 1; CEX venues 4 or 8 per coin), never by a fixed 8 |
 | `perpsAtOpenInterestCap` | `dex?` | `[coin]` |
 | `perpDexs` | | `[null, {name, fullName, deployer, ...}]` |
 | `clearinghouseState` | `user, dex?` | `{assetPositions:[{type, position:{coin, szi, entryPx, leverage{type,value,rawUsd?}, liquidationPx, marginUsed, positionValue, unrealizedPnl, returnOnEquity, cumFunding, maxLeverage}}], marginSummary{accountValue,totalNtlPos,totalRawUsd,totalMarginUsed}, crossMarginSummary, crossMaintenanceMarginUsed, withdrawable, time}` |

--- a/skills/hyperliquid-market-data/SKILL.md
+++ b/skills/hyperliquid-market-data/SKILL.md
@@ -126,10 +126,15 @@ Record the exact request (coin, interval, start, end, fetched-at, network) next 
 ```bash
 START=$(( $(date +%s000) - 7*86400000 ))
 hl "{\"type\":\"fundingHistory\",\"coin\":\"ETH\",\"startTime\":$START}" | jq -r '.[] | [.time, .fundingRate, .premium] | @tsv'
-hl '{"type":"predictedFundings"}' | jq -r '.[] | select(.[0]=="ETH") | .[1][] | [.[0], .[1].fundingRate, .[1].nextFundingTime] | @tsv'
+# venue, raw rate, its interval in hours, rate per hour, next funding
+hl '{"type":"predictedFundings"}' | jq -r '.[] | select(.[0]=="ETH") | .[1][] | select(.[1]) | [.[0], .[1].fundingRate, (.[1].fundingIntervalHours // "?"), (if .[1].fundingIntervalHours then (.[1].fundingRate|tonumber) / .[1].fundingIntervalHours else "?" end), .[1].nextFundingTime] | @tsv'
 ```
 
-`fundingHistory` returns hourly rates (up to 500 per call; paginate by `startTime`). `predictedFundings` compares venues: the `HlPerp` entry is an hourly rate; the `BinPerp`/`BybitPerp` entries are 8-hour rates, so do not compare them raw. Funding is paid every hour at `size x oracle price x hourly rate`; longs pay shorts when positive. Python: `info.funding_history(coin, start_ms)`.
+`fundingHistory` returns hourly rates (up to 500 per call; paginate by `startTime`).
+
+`predictedFundings` compares venues, and the venue rates are over **different periods**, so never compare them raw. Every coin carries the same three slots in the same order - `BinPerp`, `HlPerp`, `BybitPerp` - but match on the venue name rather than the position, and each slot is either a payload or `null` when the coin is not listed on that venue. Divide `fundingRate` by the payload's own `fundingIntervalHours` to get a per-hour rate. `HlPerp` is always 1; the CEX venues are **4 or 8 depending on the coin**, not a fixed 8: on mainnet on 2026-08-28, BinPerp was 4h for 126 coins and 8h for 63, BybitPerp 4h for 118 and 8h for 69. BTC, ETH and DOGE are all 8h, so an assumed 8 looks right on the majors and is wrong by 2x across most alts. A few BinPerp payloads (19 that day, including `TON`, `MKR` and `IP`) omit `fundingIntervalHours` entirely; treat the interval as unknown and say so rather than defaulting it.
+
+Funding is paid every hour at `size x oracle price x hourly rate`; longs pay shorts when positive. Python: `info.funding_history(coin, start_ms)`.
 
 ## Spot markets
 
@@ -156,7 +161,7 @@ Use the block in `agents/market-analyst.md`: sources and time on the first line,
 
 - Reporting a number without the request type, network and UTC time.
 - Treating `funding` as an 8h or daily rate; it is hourly.
-- Comparing `predictedFundings` venues without converting the 8h CEX rates.
+- Comparing `predictedFundings` venues without dividing each by its own `fundingIntervalHours`, or assuming the CEX venues are 8h when most coins are 4h.
 - Reading a book once and calling it "the depth" ten minutes later.
 - Forgetting spot `@index` naming and base-token `szDecimals`.
 - Expecting deep history at fine intervals; only the latest 5000 candles per interval exist, so pick the interval to fit the lookback.


### PR DESCRIPTION
The `predictedFundings` guidance told the desk that the `BinPerp` and `BybitPerp` entries are 8-hour rates and to convert them on that basis. The live API reports the period per coin in `fundingIntervalHours`, and it is 4 for most coins, so the fixed-8 rule is wrong by 2x across most of the board.

## Evidence, live API on 2026-08-28

- Mainnet `predictedFundings` covers 232 coins, each with the same three slots in order `BinPerp`, `HlPerp`, `BybitPerp`. BinPerp is 4h for 126 coins and 8h for 63; BybitPerp is 4h for 118 and 8h for 69; HlPerp is 1h for all 232. Testnet matches the pattern.
- BTC, ETH and DOGE are all 8h on both CEX venues, so the old rule looks correct on the majors and misprices the alts.
- 19 BinPerp payloads carry a rate with no `fundingIntervalHours` at all (`TON`, `MKR`, `IP` among them); 69 venue slots are `null` outright.
- The [official docs sample](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals) omits `fundingIntervalHours`, which is how the field was missed when the reference was written against the docs on 2026-08-16.

ETH shows the size of the error. Raw rates were BinPerp `0.00002234` against HlPerp `0.0000125`, which reads as Binance paying more. Per hour they are `2.79e-06` against `1.25e-05`, so Hyperliquid pays 4.5x more. A basis or carry comparison built on the old rule gets the sign of the venue spread wrong.

## Change

- `hyperliquid-api-reference`: the `predictedFundings` row documents `fundingIntervalHours`, the `null` venue slots and the per-coin period, and drops the "CEX venues 8h" claim.
- `hyperliquid-market-data`: divide by the payload own interval, treat a missing interval as unknown rather than defaulting it, and match venues by name not position. The pitfall line is updated to match.
- The jq snippet drops `null` slots and prints raw rate, interval and per-hour rate side by side. Run live against ETH (both CEX venues 8h), TON (BinPerp has no interval field, prints `?`) and CANTO (two null slots).

Documentation only; no behaviour or manifest change. `bash scripts/check.sh` passes.