### PR TITLE
fix: read the desk doctor's expected release from the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
++ `scripts/desk_doctor.py` compared `plugin.json` against a hardcoded `EXPECTED_VERSION = "1.3.0"`, so shipping 1.4.0 turned the doctor against its own release: a correct, freshly pinned clone was told `expected 1.3.0, found 1.4.0` and `SETUP.md does not pin v1.3.0`, and the check the runbook and bootstrap skill both run in section 3 exited 1 on every new desk. The doctor now reads the release from `plugin.json` and checks the `SETUP.md` pin against that, so it cannot lag the tag it ships in, and it verifies its own file is present as the "release files" detail already claimed. A test runs `check_repository` against the real repository, so this can only fail in CI.
++ `SETUP.md` section 1 pinned the clone to `v1.4.0` while the sentence directly below it still explained `v1.3.0`, telling the reader two different releases were the reviewed one. `check_manifests.py` guarded the `git clone` command but nothing else, so the prose, and the `blob/<tag>` links in the manual fallback, could drift a release behind unnoticed. The sentence no longer repeats the version, and the check now fails when any instruction file names a release tag other than the one the manifests declare. `CHANGELOG.md` and `CONTRIBUTING.md` are exempt: they describe past releases by design. Two negative fixtures cover stale prose and a stale documented URL.
+
 ## 1.4.0 - 2026-08-31
 
 + Added a versioned Grok Bot template contract for **HyperGrok Desk Lead**: exact public profile, pinned source URLs, mascot, seventeen skill paths and SHA-256 hashes, with plugins, memories and routines explicitly empty.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ The check runs three passes and CI runs the same script:
 1. Move everything in `## Unreleased` in `CHANGELOG.md` under a new version heading with today's date. Say what changed and why, not just what moved.
 2. Bump `version` in all six manifests to the new version. `check_manifests.py` fails if they disagree.
 3. Bump `metadata.version` in the frontmatter of each skill whose body actually changed. Skills version independently; leave the untouched ones alone.
-4. Update the `--branch` pin in `SETUP.md` section 1 to the new tag. `check_manifests.py` fails if it does not match the version from step 2.
+4. Update the `--branch` pin in `SETUP.md` section 1 to the new tag, and every other release tag the instruction files name. `check_manifests.py` fails if any of them disagree with the version from step 2; only `CHANGELOG.md` and this file may name older tags.
 5. Run `bash scripts/check.sh`, then commit, then tag: `git tag -a vX.Y.Z -m "..." && git push origin main vX.Y.Z`.
 6. Publish a GitHub release for the tag, and verify the published instructions actually work by running section 1 verbatim in an empty directory: clone the tag, then `bash scripts/check.sh` inside it.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -12,7 +12,7 @@ git clone --depth 1 --branch v1.4.0 https://github.com/galleonlabs/hypergrok-tra
 cd /workspace/hypergrok && git rev-parse HEAD && bash scripts/check.sh
 ```
 
-`v1.3.0` is a release tag, not a moving branch: the desk you build is the desk that was reviewed. Check the repository's releases for a newer tag before setting up, and do not swap the tag for `main` to pick up unreleased work.
+That pin is a release tag, not a moving branch: the desk you build is the desk that was reviewed. Check the repository's releases for a newer tag before setting up, and do not swap the tag for `main` to pick up unreleased work.
 
 `git clone` prints `warning: refs/tags/... is not a commit!` when it shallow-clones an annotated tag. That warning is expected and harmless: the clone still resolves to the tagged commit, which is why the command prints it. Judge the step by `scripts/check.sh`, not by that line.
 

--- a/scripts/check_manifests.py
+++ b/scripts/check_manifests.py
@@ -45,6 +45,12 @@ SKILLS_ADD_RE = re.compile(
 # in the docs must name the tag of the version the manifests declare.
 CLONE_RE = re.compile(r"git clone[^\n]*")
 CLONE_BRANCH_RE = re.compile(r"--branch(?:=|\s+)([^\s`]+)")
+# Any other way the docs name a release tag: a `blob`/`tree`/`raw` URL into this
+# repository, or prose that quotes the tag the reader is told to install.
+VERSION_TAG_RE = re.compile(r"\bv\d+\.\d+\.\d+\b")
+# `CHANGELOG.md` records every past release and `CONTRIBUTING.md` documents the
+# release procedure against historical tags; both name old versions by design.
+RELEASE_HISTORY_DOCS = ("CHANGELOG.md", "CONTRIBUTING.md")
 
 NUMBER_WORDS = {
     "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
@@ -153,7 +159,7 @@ def check_skills_pack_target(rel, kind, target, shorthand, skill_names, errors):
 
 
 def check_documented_pin(root, version, errors):
-    """A documented `git clone` of this repository must pin the released tag.
+    """An instruction file may only name the release it ships in.
 
     `CONTRIBUTING.md`: the tag must contain a `SETUP.md` that pins to that same
     tag. Bumping the manifests and forgetting the pin ships a release whose
@@ -161,15 +167,29 @@ def check_documented_pin(root, version, errors):
     loudly - the user reads one set of instructions and installs another. The
     manifest version is the release being cut, so `v<version>` is the only tag
     a clone command in these docs may name.
+
+    The clone command is not the only place a tag is written down. `SETUP.md`
+    explains the pin in prose beneath it and `README.md` links `blob/<tag>`
+    instructions for the manual fallback; both have drifted a release behind a
+    correct `--branch` pin, which tells the reader two different releases are
+    the reviewed one. So every `v<x.y.z>` in these files is held to the same
+    rule, and only the release history is allowed to name older tags.
     """
     if version is None:
         return
     expected = f"v{version}"
     for rel in markdown_files(root):
-        if rel == "CHANGELOG.md":
-            continue  # a historical record, pinned to the release it describes
+        if rel in RELEASE_HISTORY_DOCS:
+            continue  # historical records, pinned to the releases they describe
         with open(os.path.join(root, rel), encoding="utf-8") as fh:
             text = fh.read()
+        for tag in sorted(set(VERSION_TAG_RE.findall(text))):
+            if tag != expected:
+                errors.append(
+                    f"{rel}: names release tag {tag}, but the manifests declare "
+                    f"{expected}; an instruction file may only name the release "
+                    "it ships in"
+                )
         for command in CLONE_RE.findall(text):
             if REPOSITORY not in command:
                 continue  # cloning something else, or prose about `git clone`

--- a/scripts/desk_doctor.py
+++ b/scripts/desk_doctor.py
@@ -12,8 +12,7 @@ import urllib.error
 import urllib.request
 from dataclasses import asdict, dataclass
 
-EXPECTED_VERSION = "1.3.0"
-EXPECTED_TAG = f"v{EXPECTED_VERSION}"
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 EXPECTED_SKILLS = 17
 EXPECTED_AGENTS = 7
 REQUIRED_DESK_DIRS = (
@@ -40,11 +39,17 @@ def result(condition: bool, name: str, pass_detail: str, fail_detail: str) -> Ch
 
 def check_repository(root: str) -> list[Check]:
     checks = []
+    # `plugin.json` is the release this checkout claims to be. Every other
+    # release fact is read against it rather than against a constant here: a
+    # constant would have to be bumped at every release, and a doctor that
+    # lags the tag it ships in tells a correctly installed desk it is broken.
+    version = None
     try:
         with open(os.path.join(root, "plugin.json"), encoding="utf-8") as handle:
             manifest = json.load(handle)
         version = manifest.get("version")
-        checks.append(result(version == EXPECTED_VERSION, "release", f"manifest version {version}", f"expected {EXPECTED_VERSION}, found {version}"))
+        valid = isinstance(version, str) and bool(SEMVER_RE.match(version))
+        checks.append(result(valid, "release", f"manifest version {version}", f"plugin.json version {version!r} is not a release version"))
     except (OSError, json.JSONDecodeError) as exc:
         checks.append(Check("FAIL", "release", f"cannot read plugin.json: {exc}"))
 
@@ -56,15 +61,19 @@ def check_repository(root: str) -> list[Check]:
     checks.append(result(len(agents) == EXPECTED_AGENTS, "agents", f"{len(agents)} agent profiles present", f"expected {EXPECTED_AGENTS}, found {len(agents)}"))
 
     setup_path = os.path.join(root, "SETUP.md")
+    expected_tag = f"v{version}" if version else None
     try:
         with open(setup_path, encoding="utf-8") as handle:
             setup = handle.read()
-        pinned = f"--branch {EXPECTED_TAG}" in setup
-        checks.append(result(pinned, "setup pin", EXPECTED_TAG, f"SETUP.md does not pin {EXPECTED_TAG}"))
+        if expected_tag is None:
+            checks.append(Check("FAIL", "setup pin", "no manifest version to check the pin against"))
+        else:
+            pinned = f"--branch {expected_tag}" in setup
+            checks.append(result(pinned, "setup pin", expected_tag, f"SETUP.md does not pin {expected_tag}; this checkout is a half-updated release"))
     except OSError as exc:
         checks.append(Check("FAIL", "setup pin", f"cannot read SETUP.md: {exc}"))
 
-    required = ("scripts/check.sh", "scripts/opening_bell.py", "skills/hypergrok-bootstrap/SKILL.md")
+    required = ("scripts/check.sh", "scripts/desk_doctor.py", "scripts/opening_bell.py", "skills/hypergrok-bootstrap/SKILL.md")
     missing = [path for path in required if not os.path.isfile(os.path.join(root, path))]
     checks.append(result(not missing, "release files", "bootstrap, doctor and demo present", f"missing: {', '.join(missing)}"))
     return checks

--- a/scripts/test_check_manifests.py
+++ b/scripts/test_check_manifests.py
@@ -164,6 +164,18 @@ def documented_clone_is_unpinned(root):
     return "SETUP.md", "is not pinned"
 
 
+def stale_tag_in_runbook_prose(root):
+    """The pin was bumped; the sentence explaining it still names the old tag."""
+    replace(root, "SETUP.md", "That pin is a release tag", "`v0.9.0` is a release tag")
+    return "SETUP.md", "names release tag v0.9.0"
+
+
+def stale_tag_in_documented_url(root):
+    """The manual fallback still links the previous release's instructions."""
+    replace(root, "README.md", f"blob/{current_pin(root)}/SETUP.md", "blob/v0.9.0/SETUP.md")
+    return "README.md", "names release tag v0.9.0"
+
+
 FIXTURES = [
     version_mismatch,
     nested_version_mismatch,
@@ -181,6 +193,8 @@ FIXTURES = [
     documented_pin_lags_the_release,
     documented_pin_is_a_moving_branch,
     documented_clone_is_unpinned,
+    stale_tag_in_runbook_prose,
+    stale_tag_in_documented_url,
 ]
 
 

--- a/scripts/test_desk_doctor.py
+++ b/scripts/test_desk_doctor.py
@@ -32,7 +32,7 @@ class DeskDoctorTest(unittest.TestCase):
             os.makedirs(path, exist_ok=True)
             open(os.path.join(path, f"agent-{index}.md"), "w", encoding="utf-8").close()
         os.makedirs(os.path.join(root, "scripts"))
-        for name in ("check.sh", "opening_bell.py"):
+        for name in ("check.sh", "desk_doctor.py", "opening_bell.py"):
             open(os.path.join(root, "scripts", name), "w", encoding="utf-8").close()
 
     def test_repository_fixture_passes(self):
@@ -40,6 +40,25 @@ class DeskDoctorTest(unittest.TestCase):
             self.make_repo(root)
             checks = desk_doctor.check_repository(root)
             self.assertTrue(all(check.status == "PASS" for check in checks), checks)
+
+    def test_this_release_passes_its_own_doctor(self):
+        """The doctor must pass the release it ships in.
+
+        It read its expected version from a constant once, and a release that
+        bumped the manifests left every correctly installed desk being told
+        `expected 1.3.0, found 1.4.0`. Checking the real tree here means that
+        can only ever fail in CI, never in a user's first five minutes.
+        """
+        checks = desk_doctor.check_repository(ROOT)
+        self.assertEqual([check for check in checks if check.status != "PASS"], [])
+
+    def test_setup_pin_lagging_the_manifest_fails(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.make_repo(root)
+            with open(os.path.join(root, "plugin.json"), "w", encoding="utf-8") as handle:
+                json.dump({"version": "1.4.0"}, handle)
+            checks = desk_doctor.check_repository(root)
+            self.assertTrue(any(check.status == "FAIL" and check.name == "setup pin" for check in checks), checks)
 
     def test_workspace_warns_without_record_but_does_not_fail(self):
         with tempfile.TemporaryDirectory() as root:


### PR DESCRIPTION
## What was broken

`scripts/desk_doctor.py` compared `plugin.json` against a hardcoded `EXPECTED_VERSION = "1.3.0"`. Releasing 1.4.0 turned the doctor against its own release. On `main` (`eed14b2`), a correct checkout of the shipped tag reports:

```
FAIL  release        expected 1.3.0, found 1.4.0
FAIL  setup pin      SETUP.md does not pin v1.3.0
Result: 4 passed, 0 warnings, 2 failed.   (exit 1)
```

`SETUP.md` section 3 and `hypergrok-bootstrap` both run that command on first setup, so every new desk was told its correct install was broken. `scripts/check.sh` stayed green: `test_desk_doctor.py` only exercised a synthetic fixture that was also written at 1.3.0.

`SETUP.md` section 1 carried the same defect in prose. It pins the clone to `v1.4.0`, while the sentence directly below still explained `v1.3.0` — two different releases described as the reviewed one. `check_manifests.py` guarded the `git clone` command and nothing else, so that sentence and the `blob/<tag>` links in the README's manual fallback could drift a release behind unnoticed.

## The fix

- The doctor reads the release from `plugin.json` and checks the `SETUP.md` pin against it, so it cannot lag the tag it ships in. The "setup pin" check stays meaningful: it is now cross-file agreement, and fails on a half-updated tree.
- The doctor verifies `scripts/desk_doctor.py` is present, which its "bootstrap, doctor and demo present" detail already claimed.
- `check_manifests.py` fails when any instruction file names a release tag other than the one the manifests declare. `CHANGELOG.md` and `CONTRIBUTING.md` describe past releases by design and stay exempt.
- The `SETUP.md` sentence no longer repeats the version, removing the duplicate rather than bumping it.

## Guards

- `test_desk_doctor.py::test_this_release_passes_its_own_doctor` runs `check_repository` against the real repository. A desynced release can now only fail in CI, never in a user's first five minutes.
- `test_setup_pin_lagging_the_manifest_fails` proves the pin check still catches a genuinely half-updated tree.
- Two new negative fixtures in `test_check_manifests.py` (18 total): stale runbook prose, and a stale `blob/<tag>` URL in the documented manual fallback. Both derive the current pin, so a release does not break them.

## Verification

```
bash scripts/check.sh            # green: 17 skills, 7 agents, 6 manifests, 18 fixtures, 5+4 tests
python3 scripts/desk_doctor.py   # 6 passed, 0 warnings, 0 failed (incl. live /info allMids)
```

The guard was watched failing against the exact shipped defect before it was committed:

```
SETUP.md: names release tag v1.3.0, but the manifests declare v1.4.0;
an instruction file may only name the release it ships in
```

No release version is bumped here; this is a fix on top of 1.4.0.