### PR TITLE
ci: pin public template checkout to Node 24 release

### DIFF
--- a/.github/workflows/public-template.yml
+++ b/.github/workflows/public-template.yml
@@ -12,6 +12,6 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Compare the public preview with the release contract
         run: python3 scripts/check_public_template.py --live


### PR DESCRIPTION
## Why

The first production run of the new Public Grok Bot template workflow passed at `c256af8`, but GitHub annotated it because `actions/checkout@v4` targets deprecated Node 20. The repository CI already uses the current checkout release by immutable SHA.

## Change

Use the same pinned `actions/checkout` v7.0.1 SHA in the public-template workflow. This removes the deprecated runtime and keeps the dependency immutable.

## Verification

- `bash scripts/check.sh`
- `python3 scripts/check_public_template.py --live`
- `git diff --check`
- confirmed both workflows reference the same pinned checkout SHA